### PR TITLE
feat: add wasm playground

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+website/src/wasm/pkg/lk_wasm_bg.wasm filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-website/src/wasm/pkg/lk_wasm_bg.wasm filter=lfs diff=lfs merge=lfs -text
+*.wasm filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ vsc-ext/*/node_modules/
 vsc-ext/*/*.vsix
 website/node_modules/
 website/dist/
+website/src/wasm/pkg/
 
 lk-lsp-debug.log
 main

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ vsc-ext/*/node_modules/
 vsc-ext/*/*.vsix
 website/node_modules/
 website/dist/
-website/src/wasm/pkg/
+website/src/wasm/pkg/.gitignore
 
 lk-lsp-debug.log
 main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "lk-stdlib-web"
+version = "0.1.3"
+dependencies = [
+ "anyhow",
+ "lk-core",
+ "lk-stdlib-bytes",
+ "lk-stdlib-common",
+ "lk-stdlib-encoding",
+ "lk-stdlib-hash",
+ "lk-stdlib-iter",
+ "lk-stdlib-math",
+ "lk-stdlib-path",
+ "lk-stdlib-regex",
+ "lk-stdlib-slice",
+ "lk-stdlib-string",
+]
+
+[[package]]
+name = "lk-wasm"
+version = "0.1.3"
+dependencies = [
+ "anyhow",
+ "js-sys",
+ "lk-core",
+ "lk-stdlib-common",
+ "lk-stdlib-web",
+ "serde",
+ "serde-wasm-bindgen",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lkrt"
 version = "0.1.3"
 
@@ -1676,6 +1708,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "completion",
     "stdlib",
     "stdlib/common",
+    "stdlib/web",
     "stdlib/crates/bytes",
     "stdlib/crates/chan",
     "stdlib/crates/datetime",
@@ -31,6 +32,7 @@ members = [
     "lkrt",
     "lsp",
     "tree-sitter-lk",
+    "wasm",
 ]
 resolver = "2"
 
@@ -75,6 +77,9 @@ arcstr = { version = "1", features = ["serde"] }
 ureq = "2"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+js-sys = "0.3"
 
 [profile.release]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Run any example: `lk examples/syntax/closure.lk`
 
 - Rust-inspired syntax with first-class named parameters
 - Deterministic bytecode VM with optional concurrency runtime
+- Browser-playground wasm facade with a safe stdlib subset
 - Batteries-included standard library and LSP-backed tooling
 - Project website source lives in `website/` and powers [lang.lollipopkit.com](https://lang.lollipopkit.com).
 
@@ -86,6 +87,19 @@ assert_eq!(result.display_first_return(), "true");
 - Create packages and manage dependencies: `lk init`, `lk pkg add`, `lk pkg fetch`, `lk pkg tree` (see [docs/packages.md](docs/packages.md))
 
 Note: command-line paths must be relative and sanitized.
+
+#### Website and wasm playground
+
+The website lives in `website/` and includes a `/try` route that lazy-loads the LK wasm runtime.
+
+```bash
+cd website
+bun run build
+```
+
+`bun run build` first runs `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`, then regenerates i18n types and builds the Vite app. The generated `website/src/wasm/pkg/` directory is ignored and should not be committed.
+
+The browser playground supports single-file execution with stdout capture, return-value display, parse/runtime diagnostics, and an instruction step limit. It intentionally exposes only the browser-safe stdlib subset; native modules such as `fs`, `io`, `net`, `process`, `env`, `os`, `task`, and `chan` are reported as unavailable in the browser.
 
 #### VS Code
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cd website
 bun run build
 ```
 
-`bun run build` first runs `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`, then regenerates i18n types and builds the Vite app. The generated `website/src/wasm/pkg/` directory is ignored and should not be committed.
+For local development, `bun run build` runs `website/scripts/build-wasm.mjs`, which invokes `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`, then regenerates i18n types and builds the Vite app. In that workflow, `website/src/wasm/pkg/` is generated output, is typically ignored, and should not be committed. Cloudflare prebuilt/deployment branches use the checked-in wasm package instead (see `website/scripts/build-wasm.mjs`), so the checked-in `website/src/wasm/pkg/` artifacts must be retained on those branches. Workflow summary: local development regenerates and ignores `pkg/`; deployment/Cloudflare prebuild uses retained or CI-produced wasm artifacts.
 
 The browser playground supports single-file execution with stdout capture, return-value display, parse/runtime diagnostics, and an instruction step limit. It intentionally exposes only the browser-safe stdlib subset; native modules such as `fs`, `io`, `net`, `process`, `env`, `os`, `task`, and `chan` are reported as unavailable in the browser.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,6 +38,11 @@ examples/
 
 ## 特性
 
+- 类 Rust 语法，支持一等 named parameters
+- 确定性的 bytecode VM，并可选启用并发运行时
+- 可编译到浏览器 wasm 的 playground facade，内置安全标准库子集
+- 标准库、CLI、LSP 与官网源码都在同一仓库内维护
+
 ### 用法
 
 #### 集成（库）
@@ -73,6 +78,19 @@ assert_eq!(result.display_first_return(), "true");
 - 创建包并管理依赖：`lk init`、`lk pkg add`、`lk pkg fetch`、`lk pkg tree`（详见 [docs/packages.md](docs/packages.md)）
 
 注意：命令行参数路径必须为经净化的相对路径。
+
+#### Website 与 wasm playground
+
+官网位于 `website/`，新增 `/try` 路由会按需加载 LK wasm runtime。
+
+```bash
+cd website
+bun run build
+```
+
+`bun run build` 会先执行 `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`，再生成 i18n 类型并构建 Vite 应用。生成的 `website/src/wasm/pkg/` 已加入忽略列表，不应提交。
+
+浏览器 playground 支持单文件运行、stdout 捕获、返回值展示、parse/runtime 诊断和指令步数上限。它只暴露浏览器安全标准库子集；`fs`、`io`、`net`、`process`、`env`、`os`、`task`、`chan` 等 native 模块会明确报告为浏览器不可用。
 
 #### VS Code
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ cd website
 bun run build
 ```
 
-`bun run build` 会先执行 `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`，再生成 i18n 类型并构建 Vite 应用。生成的 `website/src/wasm/pkg/` 已加入忽略列表，不应提交。
+本地开发时，`bun run build` 会执行 `website/scripts/build-wasm.mjs`，由它调用 `wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release`，再生成 i18n 类型并构建 Vite 应用；此时 `website/src/wasm/pkg/` 属于生成产物，通常被 git 忽略，开发者不应提交。Cloudflare 预构建/部署分支会从仓库读取已构建 wasm package（见 `website/scripts/build-wasm.mjs`），因此这些分支上的 `website/src/wasm/pkg/` 需要存在并提交，或由 CI/CD 构建流程产出。示例：本地开发：忽略并不提交；部署/Cloudflare 预构建分支：需包含或由构建流程产出。
 
 浏览器 playground 支持单文件运行、stdout 捕获、返回值展示、parse/runtime 诊断和指令步数上限。它只暴露浏览器安全标准库子集；`fs`、`io`、`net`、`process`、`env`、`os`、`task`、`chan` 等 native 模块会明确报告为浏览器不可用。
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,8 @@ name = "lk_core"
 crate-type = ["rlib", "staticlib"]
 
 [features]
-default = ["llvm"]
+default = ["llvm", "async-runtime"]
+async-runtime = ["dep:futures", "dep:tokio"]
 llvm = ["dep:llvm-tools"]
 vm-profile = []
 
@@ -22,8 +23,8 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
 once_cell = { workspace = true }
-tokio = { workspace = true }
-futures = { workspace = true }
+tokio = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 dashmap = { workspace = true }
 tracing = { workspace = true }
 chrono = { workspace = true }

--- a/core/src/rt.rs
+++ b/core/src/rt.rs
@@ -1,3 +1,9 @@
+#[cfg(feature = "async-runtime")]
 mod runtime;
+#[cfg(not(feature = "async-runtime"))]
+mod unsupported;
 
+#[cfg(feature = "async-runtime")]
 pub use runtime::*;
+#[cfg(not(feature = "async-runtime"))]
+pub use unsupported::*;

--- a/core/src/rt/unsupported.rs
+++ b/core/src/rt/unsupported.rs
@@ -1,0 +1,55 @@
+use anyhow::{Result, anyhow};
+
+use crate::{
+    val::{HeapStore, RuntimeVal},
+    vm::copy_runtime_value,
+};
+
+#[derive(Clone, Debug)]
+pub struct RuntimePayload {
+    pub value: RuntimeVal,
+    pub heap: HeapStore,
+}
+
+impl RuntimePayload {
+    pub fn new(value: RuntimeVal, heap: HeapStore) -> Self {
+        Self { value, heap }
+    }
+
+    pub fn copy_from_value(value: &RuntimeVal, heap: &HeapStore) -> Result<Self> {
+        let mut payload_heap = HeapStore::new();
+        let value = copy_runtime_value(value, heap, &mut payload_heap)?;
+        Ok(Self::new(value, payload_heap))
+    }
+
+    pub fn into_value(self, heap: &mut HeapStore) -> Result<RuntimeVal> {
+        copy_runtime_value(&self.value, &self.heap, heap)
+    }
+
+    pub fn clone_value_into(&self, heap: &mut HeapStore) -> Result<RuntimeVal> {
+        copy_runtime_value(&self.value, &self.heap, heap)
+    }
+
+    pub fn nil() -> Self {
+        Self {
+            value: RuntimeVal::Nil,
+            heap: HeapStore::new(),
+        }
+    }
+}
+
+pub fn init_runtime() -> Result<()> {
+    Ok(())
+}
+
+pub fn shutdown_runtime() {}
+
+pub fn with_runtime<F, R>(_f: F) -> Result<R>
+where
+    F: FnOnce(&Runtime) -> Result<R>,
+{
+    Err(anyhow!("LK async runtime is not available in this build"))
+}
+
+#[derive(Debug)]
+pub struct Runtime;

--- a/core/src/stmt/import.rs
+++ b/core/src/stmt/import.rs
@@ -151,8 +151,9 @@ impl ModuleResolver {
     }
 
     pub fn resolve_runtime_module(&self, name: &str) -> Result<RuntimeExport> {
-        if let Ok(module) = self.stdlib_registry.get_runtime_module(name) {
-            return Ok(module);
+        match self.stdlib_registry.get_module(name) {
+            Ok(module) => return module.runtime_exports(),
+            Err(_) => {}
         }
         let Some(root) = self.package_modules.get(name) else {
             return Err(anyhow!("Module '{}' not found", name));

--- a/core/src/vm/exec.rs
+++ b/core/src/vm/exec.rs
@@ -571,6 +571,7 @@ impl Executor {
                     if self.pc >= code.len() || code[self.pc].opcode() != Opcode::Move {
                         break;
                     }
+                    self.consume_instruction()?;
                 },
                 Opcode::Move2 => {
                     let first = *self.read_unchecked(instr.b());

--- a/core/src/vm/exec.rs
+++ b/core/src/vm/exec.rs
@@ -24,7 +24,7 @@ pub use super::RuntimeCallable;
 pub use imports::import_runtime_export;
 pub use program::{
     compile_program_module_with_ctx, execute_compiled_module_with_ctx, execute_module_artifact_with_ctx,
-    execute_program, execute_program_with_ctx, execute_source,
+    execute_program, execute_program_with_ctx, execute_program_with_ctx_and_budget, execute_source,
 };
 #[cfg(test)]
 pub(crate) use runtime_callable::call_runtime_callable_test;
@@ -321,6 +321,8 @@ pub struct Executor {
     collect_metrics: bool,
     gc_pending: bool,
     shared_module: Option<Arc<Module>>,
+    instruction_budget: Option<u64>,
+    instruction_count: u64,
 }
 
 impl Executor {
@@ -337,9 +339,30 @@ impl Executor {
             collect_metrics: false,
             gc_pending: false,
             shared_module: None,
+            instruction_budget: None,
+            instruction_count: 0,
         };
         this.reset_entry_frame(register_count);
         this
+    }
+
+    pub fn with_instruction_budget(mut self, budget: u64) -> Self {
+        self.instruction_budget = Some(budget);
+        self
+    }
+
+    #[inline]
+    fn consume_instruction(&mut self) -> Result<()> {
+        self.instruction_count = self
+            .instruction_count
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("instruction counter overflow"))?;
+        if let Some(budget) = self.instruction_budget
+            && self.instruction_count > budget
+        {
+            bail!("execution step limit exceeded ({budget} instructions)");
+        }
+        Ok(())
     }
 
     pub fn run_function(self, function: &Function) -> Result<ExecResult> {
@@ -523,6 +546,7 @@ impl Executor {
         let code = &function.code;
         let mut profile = RuntimeProfileFrame::new();
         while self.pc < code.len() {
+            self.consume_instruction()?;
             let instr = code[self.pc];
             let opcode = instr.opcode();
             profile.record_opcode(opcode, collect_metrics);

--- a/core/src/vm/exec/program.rs
+++ b/core/src/vm/exec/program.rs
@@ -117,10 +117,10 @@ mod tests {
 
     use crate::{
         val::{HeapStore, HeapValue, RuntimeVal},
-        vm::{GlobalSlot, RuntimeExport, RuntimeModuleState, VmContext},
+        vm::{Function, GlobalSlot, Instr, Module, Opcode, RuntimeExport, RuntimeModuleState, VmContext},
     };
 
-    use super::seed_module_globals;
+    use super::{execute_compiled_module_with_ctx_and_budget, seed_module_globals};
 
     #[test]
     fn seed_module_globals_imports_by_module_slot_order_without_name_map() {
@@ -152,5 +152,35 @@ mod tests {
             panic!("external global should use as heap object");
         };
         assert!(matches!(dest_heap.get(imported), Some(HeapValue::String(value)) if value.as_ref() == "external"));
+    }
+
+    #[test]
+    fn move_batch_consumes_budget_per_move() {
+        let mut function = Function {
+            register_count: 4,
+            ..Function::default()
+        };
+        let int_index = function.consts.push_int(7).expect("push int");
+        function.code = vec![
+            Instr::abx(Opcode::LoadInt, 0, int_index),
+            Instr::abc(Opcode::Move, 1, 0, 0),
+            Instr::abc(Opcode::Move, 2, 1, 0),
+            Instr::abc(Opcode::Move, 3, 2, 0),
+            Instr::abc(Opcode::Return, 3, 1, 0),
+        ];
+        let module = Arc::new(Module::single(function));
+
+        let mut limited_ctx = VmContext::new_without_core_vm_builtins();
+        let error = execute_compiled_module_with_ctx_and_budget(Arc::clone(&module), &mut limited_ctx, 3)
+            .expect_err("three-instruction budget should not cover three moves after load");
+        assert!(
+            error.to_string().contains("execution step limit exceeded"),
+            "unexpected error: {error}"
+        );
+
+        let mut enough_ctx = VmContext::new_without_core_vm_builtins();
+        let result = execute_compiled_module_with_ctx_and_budget(module, &mut enough_ctx, 5)
+            .expect("budget should count each batched Move and complete");
+        assert_eq!(result.returns.first(), Some(&RuntimeVal::Int(7)));
     }
 }

--- a/core/src/vm/exec/program.rs
+++ b/core/src/vm/exec/program.rs
@@ -41,6 +41,15 @@ pub fn execute_program_with_ctx(program: &Program, ctx: &mut VmContext) -> Resul
     execute_compiled_module_with_ctx(module, ctx)
 }
 
+pub fn execute_program_with_ctx_and_budget(
+    program: &Program,
+    ctx: &mut VmContext,
+    instruction_budget: u64,
+) -> Result<ProgramResult> {
+    let module = compile_program_module_with_ctx(program, ctx)?;
+    execute_compiled_module_with_ctx_and_budget(module, ctx, instruction_budget)
+}
+
 pub fn execute_module_artifact_with_ctx(artifact: ModuleArtifact, ctx: &mut VmContext) -> Result<ProgramResult> {
     let imports = artifact.imports.clone();
     let resolver = ctx.resolver().clone();
@@ -50,18 +59,34 @@ pub fn execute_module_artifact_with_ctx(artifact: ModuleArtifact, ctx: &mut VmCo
 }
 
 pub fn execute_compiled_module_with_ctx(module: Arc<crate::vm::Module>, ctx: &mut VmContext) -> Result<ProgramResult> {
+    execute_compiled_module_with_ctx_inner(module, ctx, None)
+}
+
+fn execute_compiled_module_with_ctx_and_budget(
+    module: Arc<crate::vm::Module>,
+    ctx: &mut VmContext,
+    instruction_budget: u64,
+) -> Result<ProgramResult> {
+    execute_compiled_module_with_ctx_inner(module, ctx, Some(instruction_budget))
+}
+
+fn execute_compiled_module_with_ctx_inner(
+    module: Arc<crate::vm::Module>,
+    ctx: &mut VmContext,
+    instruction_budget: Option<u64>,
+) -> Result<ProgramResult> {
     let mut seed_heap = HeapStore::new();
     let globals = seed_module_globals(&module.globals, ctx, &mut seed_heap)?;
     let register_count = module
         .entry_function()
         .map(|function| function.register_count)
         .unwrap_or_default();
-    let result = Executor::new(register_count).run_shared_module_with_globals_and_heap_and_ctx(
-        Arc::clone(&module),
-        globals,
-        seed_heap,
-        ctx,
-    )?;
+    let mut executor = Executor::new(register_count);
+    if let Some(instruction_budget) = instruction_budget {
+        executor = executor.with_instruction_budget(instruction_budget);
+    }
+    let result =
+        executor.run_shared_module_with_globals_and_heap_and_ctx(Arc::clone(&module), globals, seed_heap, ctx)?;
     Ok(ProgramResult {
         returns: result.returns,
         state: result.state,

--- a/stdlib/web/Cargo.toml
+++ b/stdlib/web/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "lk-stdlib-web"
+description = "Browser-safe standard library subset for LK"
+version = "0.1.3"
+edition = "2024"
+authors = ["lollipopkit <a@lpkt.cn>"]
+license = "Apache-2.0"
+
+[lib]
+name = "lk_stdlib_web"
+crate-type = ["rlib"]
+
+[dependencies]
+anyhow = { workspace = true }
+lk-core = { path = "../../core", default-features = false }
+lk-stdlib-bytes = { path = "../crates/bytes" }
+lk-stdlib-common = { path = "../common" }
+lk-stdlib-encoding = { path = "../crates/encoding" }
+lk-stdlib-hash = { path = "../crates/hash" }
+lk-stdlib-iter = { path = "../crates/iter" }
+lk-stdlib-math = { path = "../crates/math" }
+lk-stdlib-path = { path = "../crates/path" }
+lk-stdlib-regex = { path = "../crates/regex" }
+lk-stdlib-slice = { path = "../crates/slice" }
+lk-stdlib-string = { path = "../crates/string" }

--- a/stdlib/web/src/lib.rs
+++ b/stdlib/web/src/lib.rs
@@ -1,0 +1,242 @@
+use std::cell::RefCell;
+
+use anyhow::{Result, anyhow};
+use lk_core::{
+    module::{ModuleProvider, ModuleRegistry},
+    val::RuntimeVal,
+    vm::{NativeArgs, NativeEntry, NativeFunction, NativeRuntime, RuntimeExport},
+};
+use lk_stdlib_common::runtime_native::runtime_display_value;
+
+thread_local! {
+    static STDOUT: RefCell<String> = const { RefCell::new(String::new()) };
+}
+
+const UNSUPPORTED_MODULES: &[&str] = &[
+    "chan", "datetime", "env", "fs", "http", "io", "net", "os", "process", "random", "stream", "task", "time", "uuid",
+];
+
+pub fn clear_stdout() {
+    STDOUT.with(|stdout| stdout.borrow_mut().clear());
+}
+
+pub fn take_stdout() -> String {
+    STDOUT.with(|stdout| std::mem::take(&mut *stdout.borrow_mut()))
+}
+
+pub fn register_web_stdlib_globals(registry: &mut ModuleRegistry) {
+    register_runtime_builtin(registry, "print", print, NativeEntry::VARIADIC);
+    register_runtime_builtin(registry, "println", println, NativeEntry::VARIADIC);
+    register_runtime_builtin(registry, "panic", panic, NativeEntry::VARIADIC);
+    register_runtime_builtin(registry, "assert", assert, NativeEntry::VARIADIC);
+    register_runtime_builtin(registry, "assert_eq", assert_eq, NativeEntry::VARIADIC);
+    register_runtime_builtin(registry, "assert_ne", assert_ne, NativeEntry::VARIADIC);
+}
+
+pub fn register_web_stdlib_modules(registry: &mut ModuleRegistry) -> Result<()> {
+    lk_stdlib_bytes::register(registry)?;
+    lk_stdlib_encoding::register(registry)?;
+    lk_stdlib_hash::register(registry)?;
+    lk_stdlib_iter::register(registry)?;
+    lk_stdlib_math::register(registry)?;
+    lk_stdlib_path::register(registry)?;
+    lk_stdlib_regex::register(registry)?;
+    lk_stdlib_slice::register(registry)?;
+    lk_stdlib_string::register(registry)?;
+
+    for name in UNSUPPORTED_MODULES {
+        registry.register_module(name, Box::new(UnsupportedWebModule { name }))?;
+    }
+    Ok(())
+}
+
+pub fn register_web_stdlib(registry: &mut ModuleRegistry) -> Result<()> {
+    register_web_stdlib_globals(registry);
+    register_web_stdlib_modules(registry)
+}
+
+fn register_runtime_builtin(
+    registry: &mut ModuleRegistry,
+    name: &str,
+    function: fn(NativeArgs<'_>, &mut NativeRuntime<'_>) -> Result<RuntimeVal>,
+    arity: u16,
+) {
+    registry.register_runtime_builtin(name, NativeFunction::FullState(function), arity);
+}
+
+fn print(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    let text = format_variadic_runtime(args.as_slice(), runtime)?;
+    STDOUT.with(|stdout| stdout.borrow_mut().push_str(&text));
+    Ok(RuntimeVal::Nil)
+}
+
+fn println(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    let text = format_variadic_runtime(args.as_slice(), runtime)?;
+    STDOUT.with(|stdout| {
+        let mut stdout = stdout.borrow_mut();
+        stdout.push_str(&text);
+        stdout.push('\n');
+    });
+    Ok(RuntimeVal::Nil)
+}
+
+fn panic(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    let message = if args.is_empty() {
+        "panic".to_string()
+    } else {
+        join_runtime_display(args.as_slice(), runtime)?
+    };
+    Err(anyhow!("{message}"))
+}
+
+fn assert(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    expect_assert_args(args, 1, 2, "assert")?;
+    let values = args.as_slice();
+    if assert_truthy(&values[0]) {
+        return Ok(RuntimeVal::Nil);
+    }
+    let message = if let Some(message) = values.get(1) {
+        format!("assertion failed: {}", runtime_display(message, runtime)?)
+    } else {
+        "assertion failed".to_string()
+    };
+    Err(anyhow!("{message}"))
+}
+
+fn assert_eq(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    expect_assert_args(args, 2, 3, "assert_eq")?;
+    let values = args.as_slice();
+    if runtime_values_equal(&values[0], &values[1]) {
+        return Ok(RuntimeVal::Nil);
+    }
+    let actual = runtime_display(&values[0], runtime)?;
+    let expected = runtime_display(&values[1], runtime)?;
+    let mut message = format!("assertion failed: expected {expected}, got {actual}");
+    if let Some(extra) = values.get(2) {
+        message.push_str(" - ");
+        message.push_str(&runtime_display(extra, runtime)?);
+    }
+    Err(anyhow!("{message}"))
+}
+
+fn assert_ne(args: NativeArgs<'_>, runtime: &mut NativeRuntime<'_>) -> Result<RuntimeVal> {
+    expect_assert_args(args, 2, 3, "assert_ne")?;
+    let values = args.as_slice();
+    if !runtime_values_equal(&values[0], &values[1]) {
+        return Ok(RuntimeVal::Nil);
+    }
+    let mut message = "assertion failed: values should not be equal".to_string();
+    if let Some(extra) = values.get(2) {
+        message.push_str(" - ");
+        message.push_str(&runtime_display(extra, runtime)?);
+    }
+    Err(anyhow!("{message}"))
+}
+
+fn format_variadic_runtime(args: &[RuntimeVal], runtime: &mut NativeRuntime<'_>) -> Result<String> {
+    if args.is_empty() {
+        return Ok(String::new());
+    }
+    let Some(format) = runtime_string_maybe(&args[0], runtime)? else {
+        return join_runtime_display(args, runtime);
+    };
+    let rest = &args[1..];
+    let mut out = String::with_capacity(format.len() + rest.len() * 8);
+    let mut chars = format.chars().peekable();
+    let mut arg_index = 0usize;
+    while let Some(ch) = chars.next() {
+        if ch == '{' && chars.peek() == Some(&'}') {
+            chars.next();
+            if let Some(value) = rest.get(arg_index) {
+                out.push_str(&runtime_display(value, runtime)?);
+                arg_index += 1;
+            } else {
+                out.push_str("{}");
+            }
+        } else {
+            out.push(ch);
+        }
+    }
+    if arg_index < rest.len() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(&join_runtime_display(&rest[arg_index..], runtime)?);
+    }
+    Ok(out)
+}
+
+fn join_runtime_display(args: &[RuntimeVal], runtime: &mut NativeRuntime<'_>) -> Result<String> {
+    let mut out = String::new();
+    for (index, value) in args.iter().enumerate() {
+        if index > 0 {
+            out.push(' ');
+        }
+        out.push_str(&runtime_display(value, runtime)?);
+    }
+    Ok(out)
+}
+
+fn runtime_display(value: &RuntimeVal, runtime: &mut NativeRuntime<'_>) -> Result<String> {
+    runtime_display_value(value, runtime.heap())
+}
+
+fn runtime_string_maybe(value: &RuntimeVal, runtime: &mut NativeRuntime<'_>) -> Result<Option<String>> {
+    Ok(match value {
+        RuntimeVal::ShortStr(value) => Some(value.as_str().to_string()),
+        RuntimeVal::Obj(handle) => match runtime.heap().get(*handle) {
+            Some(lk_core::val::HeapValue::String(value)) => Some(value.to_string()),
+            Some(_) => None,
+            None => return Err(anyhow!("heap object {} out of bounds", handle.index())),
+        },
+        _ => None,
+    })
+}
+
+fn runtime_values_equal(left: &RuntimeVal, right: &RuntimeVal) -> bool {
+    left == right
+}
+
+fn expect_assert_args(args: NativeArgs<'_>, min: usize, max: usize, name: &str) -> Result<()> {
+    if args.has_named() {
+        return Err(anyhow!("{name}() does not accept named arguments"));
+    }
+    let len = args.len();
+    if (min..=max).contains(&len) {
+        Ok(())
+    } else if min == max {
+        Err(anyhow!("{name}() expects exactly {min} arguments"))
+    } else {
+        Err(anyhow!("{name}() expects {min} or {max} arguments"))
+    }
+}
+
+fn assert_truthy(value: &RuntimeVal) -> bool {
+    !matches!(value, RuntimeVal::Nil | RuntimeVal::Bool(false))
+}
+
+#[derive(Debug)]
+struct UnsupportedWebModule {
+    name: &'static str,
+}
+
+impl ModuleProvider for UnsupportedWebModule {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn description(&self) -> &str {
+        "Unavailable in the browser playground"
+    }
+
+    fn register(&self, _registry: &mut ModuleRegistry) -> Result<()> {
+        Ok(())
+    }
+
+    fn runtime_exports(&self) -> Result<RuntimeExport> {
+        Err(anyhow!(
+            "module '{}' is not available in the browser playground",
+            self.name
+        ))
+    }
+}

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "lk-wasm"
+description = "Wasm facade for LK browser playground"
+version = "0.1.3"
+edition = "2024"
+authors = ["lollipopkit <a@lpkt.cn>"]
+license = "Apache-2.0"
+
+[lib]
+name = "lk_wasm"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+anyhow = { workspace = true }
+js-sys = { workspace = true }
+lk-core = { path = "../core", default-features = false }
+lk-stdlib-common = { path = "../stdlib/common" }
+lk-stdlib-web = { path = "../stdlib/web" }
+serde = { workspace = true, features = ["derive"] }
+serde-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use lk_core::{
+    module::ModuleRegistry,
+    stmt::{ModuleResolver, StmtParser},
+    token::Tokenizer,
+    typ::TypeChecker,
+    vm::{VmContext, execute_program_with_ctx_and_budget},
+};
+use lk_stdlib_common::runtime_native::runtime_display_value;
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+const DEFAULT_INSTRUCTION_BUDGET: u64 = 1_000_000;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RunResult {
+    ok: bool,
+    stdout: String,
+    result: Option<String>,
+    error: Option<String>,
+    diagnostics: Vec<Diagnostic>,
+    elapsed_ms: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Diagnostic {
+    level: &'static str,
+    message: String,
+    rendered: Option<String>,
+    line: Option<u32>,
+    column: Option<u32>,
+}
+
+#[wasm_bindgen(js_name = runLk)]
+pub fn run_lk(source: &str) -> JsValue {
+    let started = js_sys::Date::now();
+    lk_stdlib_web::clear_stdout();
+    let result = run_lk_inner(source);
+    let elapsed_ms = js_sys::Date::now() - started;
+
+    let output = match result {
+        Ok(result) => RunResult {
+            ok: true,
+            stdout: lk_stdlib_web::take_stdout(),
+            result: Some(result),
+            error: None,
+            diagnostics: Vec::new(),
+            elapsed_ms,
+        },
+        Err(error) => RunResult {
+            ok: false,
+            stdout: lk_stdlib_web::take_stdout(),
+            result: None,
+            error: Some(error.message.clone()),
+            diagnostics: vec![error],
+            elapsed_ms,
+        },
+    };
+
+    serde_wasm_bindgen::to_value(&output).expect("RunResult should serialize")
+}
+
+fn run_lk_inner(source: &str) -> Result<String, Diagnostic> {
+    let (tokens, spans) = Tokenizer::tokenize_enhanced_with_spans(source).map_err(|error| Diagnostic {
+        level: "error",
+        message: error.to_string(),
+        rendered: Some(error.display_with_source(source)),
+        line: error.span.as_ref().map(|span| span.start.line),
+        column: error.span.as_ref().map(|span| span.start.column),
+    })?;
+
+    let mut parser = StmtParser::new_with_spans(&tokens, &spans);
+    let program = parser
+        .parse_program_with_enhanced_errors(source)
+        .map_err(|error| Diagnostic {
+            level: "error",
+            message: error.to_string(),
+            rendered: Some(error.display_with_source(source)),
+            line: error.span.as_ref().map(|span| span.start.line),
+            column: error.span.as_ref().map(|span| span.start.column),
+        })?;
+
+    let mut registry = ModuleRegistry::new();
+    lk_stdlib_web::register_web_stdlib(&mut registry).map_err(runtime_diagnostic)?;
+    let resolver = Arc::new(ModuleResolver::with_registry(registry));
+    let mut ctx = VmContext::new()
+        .with_resolver(resolver)
+        .with_type_checker(Some(TypeChecker::new_strict()));
+    let result = execute_program_with_ctx_and_budget(&program, &mut ctx, DEFAULT_INSTRUCTION_BUDGET)
+        .map_err(runtime_diagnostic)?;
+    runtime_display_value(result.first_return(), result.state.heap()).map_err(runtime_diagnostic)
+}
+
+fn runtime_diagnostic(error: impl std::fmt::Display) -> Diagnostic {
+    Diagnostic {
+        level: "error",
+        message: error.to_string(),
+        rendered: None,
+        line: None,
+        column: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_lk_inner;
+
+    #[test]
+    fn runs_trait_methods_in_wasm_context() {
+        let source = r#"
+struct Rect { w: Int, h: Int }
+
+trait Area {
+  fn area(self) -> Int;
+}
+
+impl Area for Rect {
+  fn area(self) -> Int { return self.w * self.h; }
+}
+
+let shape = Rect { w: 8, h: 5 };
+return shape.area();
+"#;
+
+        assert_eq!(run_lk_inner(source).expect("trait example should run"), "40");
+    }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "wasm": "wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release",
+    "dev": "bun run wasm && vite",
     "typesafe-i18n": "typesafe-i18n --no-watch",
-    "build": "bun run typesafe-i18n && vite build",
+    "build": "bun run wasm && bun run typesafe-i18n && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "wasm": "wasm-pack build ../wasm --target web --out-dir ../website/src/wasm/pkg --release",
+    "wasm": "node scripts/build-wasm.mjs",
     "dev": "bun run wasm && vite",
     "typesafe-i18n": "typesafe-i18n --no-watch",
     "build": "bun run wasm && bun run typesafe-i18n && vite build",

--- a/website/scripts/build-wasm.mjs
+++ b/website/scripts/build-wasm.mjs
@@ -1,0 +1,32 @@
+import { existsSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+const prebuiltFiles = [
+  'src/wasm/pkg/lk_wasm.js',
+  'src/wasm/pkg/lk_wasm.d.ts',
+  'src/wasm/pkg/lk_wasm_bg.wasm',
+  'src/wasm/pkg/lk_wasm_bg.wasm.d.ts',
+  'src/wasm/pkg/package.json',
+]
+
+const hasPrebuiltWasm = prebuiltFiles.every((file) => existsSync(join(process.cwd(), file)))
+const isCloudflarePages = process.env.CF_PAGES === '1' || process.env.CF_PAGES === 'true'
+
+if (isCloudflarePages && hasPrebuiltWasm) {
+  console.log('Using checked-in LK wasm package for Cloudflare Pages build.')
+  process.exit(0)
+}
+
+const result = spawnSync(
+  'wasm-pack',
+  ['build', '../wasm', '--target', 'web', '--out-dir', '../website/src/wasm/pkg', '--release'],
+  { stdio: 'inherit' },
+)
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)

--- a/website/src/App.svelte
+++ b/website/src/App.svelte
@@ -10,6 +10,8 @@
     localeStorageKey,
     syncLocaleToUrl,
   } from './lib/i18n'
+  import { highlightLkCode } from './lib/highlight'
+  import Playground from './components/Playground.svelte'
   import {
     ArrowRight,
     Boxes,
@@ -31,7 +33,7 @@
 
   type NavItem = {
     href: string
-    label: 'spec' | 'github'
+    label: 'try' | 'spec' | 'github'
     external?: boolean
   }
 
@@ -71,6 +73,7 @@
   }
 
   const navItems: NavItem[] = [
+    { href: '/try', label: 'try' },
     { href: '/spec', label: 'spec' },
     { href: 'https://github.com/lollipopkit/lk', label: 'github', external: true },
   ]
@@ -215,201 +218,6 @@ let total = iter.reduce(iter.range(0, 10, 2), 0, |acc, n| acc + n);`,
   $: activeLangDocument = locale === 'zh-CN' ? langZhDocument : langDocument
   $: specSections = parseMarkdown(activeLangDocument)
   $: specNav = buildSpecNav(specSections)
-
-  const lkKeywords = new Set([
-    'if',
-    'else',
-    'while',
-    'for',
-    'in',
-    'match',
-    'return',
-    'break',
-    'continue',
-    'select',
-    'case',
-    'default',
-    'let',
-    'const',
-    'fn',
-    'struct',
-    'trait',
-    'impl',
-    'use',
-    'from',
-    'as',
-    'spawn',
-    'chan',
-    'send',
-    'recv',
-  ])
-
-  const lkTypes = new Set([
-    'Int',
-    'Float',
-    'String',
-    'Bool',
-    'Nil',
-    'Any',
-    'List',
-    'Map',
-    'Task',
-    'Channel',
-    'Function',
-    'Object',
-    'Stream',
-    'StreamCursor',
-    'Iterator',
-    'MutationGuard',
-  ])
-
-  const lkConstants = new Set(['true', 'false', 'nil'])
-
-  function escapeHtml(value: string): string {
-    return value
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&#39;')
-  }
-
-  function wrapToken(kind: string, value: string): string {
-    return `<span class="lk-token lk-${kind}">${escapeHtml(value)}</span>`
-  }
-
-  function isIdentifierStart(char: string | undefined): boolean {
-    return !!char && /[A-Za-z_]/.test(char)
-  }
-
-  function isIdentifierPart(char: string | undefined): boolean {
-    return !!char && /[A-Za-z0-9_-]/.test(char)
-  }
-
-  function readQuotedString(source: string, start: number, quote: string): number {
-    let index = start + 1
-    while (index < source.length) {
-      if (source[index] === '\\') {
-        index += 2
-        continue
-      }
-      if (source[index] === quote) return index + 1
-      index += 1
-    }
-    return source.length
-  }
-
-  function readRawString(source: string, start: number): number | undefined {
-    const opener = source.slice(start).match(/^r(#+)?"/)
-    if (!opener) return undefined
-
-    const hashes = opener[1] || ''
-    const close = `"${hashes}`
-    const contentStart = start + opener[0].length
-    const closeIndex = source.indexOf(close, contentStart)
-    return closeIndex === -1 ? source.length : closeIndex + close.length
-  }
-
-  function highlightLkCode(source: string): string {
-    let html = ''
-    let index = 0
-    let inBlockComment = false
-
-    while (index < source.length) {
-      if (inBlockComment) {
-        const end = source.indexOf('*/', index)
-        const nextIndex = end === -1 ? source.length : end + 2
-        html += wrapToken('comment', source.slice(index, nextIndex))
-        index = nextIndex
-        inBlockComment = end === -1
-        continue
-      }
-
-      const char = source[index]
-      const next = source[index + 1]
-
-      if (char === '/' && next === '*') {
-        const end = source.indexOf('*/', index + 2)
-        const nextIndex = end === -1 ? source.length : end + 2
-        html += wrapToken('comment', source.slice(index, nextIndex))
-        index = nextIndex
-        inBlockComment = end === -1
-        continue
-      }
-
-      if (char === '/' && next === '/') {
-        const end = source.indexOf('\n', index)
-        const nextIndex = end === -1 ? source.length : end
-        html += wrapToken('comment', source.slice(index, nextIndex))
-        index = nextIndex
-        continue
-      }
-
-      const rawStringEnd = char === 'r' ? readRawString(source, index) : undefined
-      if (rawStringEnd !== undefined) {
-        html += wrapToken('string', source.slice(index, rawStringEnd))
-        index = rawStringEnd
-        continue
-      }
-
-      if (char === '"' || char === "'" || char === '`') {
-        const end = readQuotedString(source, index, char)
-        html += wrapToken('string', source.slice(index, end))
-        index = end
-        continue
-      }
-
-      if (/\d/.test(char)) {
-        const match = source.slice(index).match(/^\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/)
-        if (match) {
-          html += wrapToken('number', match[0])
-          index += match[0].length
-          continue
-        }
-      }
-
-      if (isIdentifierStart(char)) {
-        let end = index + 1
-        while (isIdentifierPart(source[end])) end += 1
-        const word = source.slice(index, end)
-        const rest = source.slice(end).replace(/^\s+/, '')
-
-        if (lkConstants.has(word)) {
-          html += wrapToken('constant', word)
-        } else if (lkTypes.has(word)) {
-          html += wrapToken('type', word)
-        } else if (lkKeywords.has(word)) {
-          html += wrapToken('keyword', word)
-        } else if (rest.startsWith('(')) {
-          html += wrapToken('function', word)
-        } else {
-          html += escapeHtml(word)
-        }
-        index = end
-        continue
-      }
-
-      const operator = source
-        .slice(index)
-        .match(/^(?:\?\?|\?\.|\?\[|=>|->|\.\.=|\.\.|==|!=|<=|>=|\+=|-=|\*=|\/=|%=|&&|\|\||:=|[+\-*/%&|~!?:=<>])/)
-      if (operator) {
-        html += wrapToken('operator', operator[0])
-        index += operator[0].length
-        continue
-      }
-
-      if (/[\[\]{}().,;]/.test(char)) {
-        html += wrapToken('punctuation', char)
-        index += 1
-        continue
-      }
-
-      html += escapeHtml(char)
-      index += 1
-    }
-
-    return html
-  }
 
   function slugify(value: string): string {
     return value
@@ -674,6 +482,8 @@ let total = iter.reduce(iter.range(0, 10, 2), 0, |acc, n| acc + n);`,
         {/each}
       </div>
     </section>
+  {:else if currentPath === '/try'}
+    <Playground />
   {:else}
     <section class="hero" aria-labelledby="hero-title">
       <div class="hero-copy">

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -283,6 +283,7 @@ code {
 
 .language-switcher select:focus-visible,
 .site-nav a:focus-visible,
+.icon-btn:focus-visible,
 .btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;

--- a/website/src/app.css
+++ b/website/src/app.css
@@ -210,6 +210,35 @@ code {
   color: var(--ink);
 }
 
+.icon-btn {
+  display: inline-grid;
+  width: 2.35rem;
+  height: 2.35rem;
+  place-items: center;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  background: var(--card-bg-soft);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.icon-btn:hover:not(:disabled) {
+  border-color: var(--line-strong);
+  color: var(--ink);
+}
+
+.icon-btn:active:not(:disabled),
+.btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.icon-btn:disabled,
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .nav-link {
   justify-content: center;
   min-height: 2.25rem;
@@ -932,46 +961,6 @@ h2 {
   white-space: pre;
 }
 
-.lk-keyword {
-  color: var(--syntax-keyword);
-  font-weight: 600;
-}
-
-.lk-function {
-  color: var(--syntax-function);
-}
-
-.lk-string {
-  color: var(--syntax-string);
-}
-
-.lk-number {
-  color: var(--syntax-number);
-}
-
-.lk-constant {
-  color: var(--syntax-constant);
-  font-weight: 600;
-}
-
-.lk-type {
-  color: var(--syntax-type);
-  font-weight: 600;
-}
-
-.lk-operator {
-  color: var(--syntax-operator);
-}
-
-.lk-punctuation {
-  color: var(--syntax-punctuation);
-}
-
-.lk-comment {
-  color: var(--syntax-comment);
-  font-style: italic;
-}
-
 .site-footer {
   display: flex;
   flex-wrap: wrap;
@@ -1077,6 +1066,7 @@ h2 {
   .spec-level-4 {
     margin-left: 0;
   }
+
 }
 
 @media (max-width: 560px) {
@@ -1117,4 +1107,5 @@ h2 {
     grid-row: auto;
     min-height: 3.5rem;
   }
+
 }

--- a/website/src/components/LkCodeEditor.svelte
+++ b/website/src/components/LkCodeEditor.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { highlightLkCode } from '../lib/highlight'
+
+  export let value = ''
+  export let ariaLabel = 'LK source code'
+
+  let highlightLayer: HTMLPreElement
+
+  function syncScroll(event: Event): void {
+    const textarea = event.currentTarget as HTMLTextAreaElement
+    if (!highlightLayer) return
+    highlightLayer.scrollTop = textarea.scrollTop
+    highlightLayer.scrollLeft = textarea.scrollLeft
+  }
+</script>
+
+<div class="lk-code-editor">
+  <pre class="lk-code-editor-highlight" aria-hidden="true" bind:this={highlightLayer}><code>{@html highlightLkCode(value)}</code>{#if value.endsWith('\n')}<br />{/if}</pre>
+  <textarea bind:value spellcheck="false" aria-label={ariaLabel} on:scroll={syncScroll}></textarea>
+</div>
+
+<style>
+  .lk-code-editor {
+    position: relative;
+    min-height: 28rem;
+    background: var(--code-bg-strong);
+  }
+
+  .lk-code-editor-highlight,
+  .lk-code-editor textarea {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 28rem;
+    margin: 0;
+    border: 0;
+    font: 500 0.91rem/1.7 var(--font-mono);
+    letter-spacing: 0;
+    padding: 1.25rem;
+    tab-size: 2;
+    white-space: pre;
+    overflow: auto;
+  }
+
+  .lk-code-editor-highlight {
+    pointer-events: none;
+    background: var(--code-bg-strong);
+    color: var(--code-text);
+  }
+
+  .lk-code-editor-highlight code {
+    display: block;
+    min-width: 100%;
+  }
+
+  .lk-code-editor textarea {
+    z-index: 1;
+    resize: none;
+    outline: 0;
+    background: transparent;
+    color: transparent;
+    caret-color: var(--code-text);
+  }
+
+  .lk-code-editor textarea::selection {
+    background: rgba(145, 124, 86, 0.34);
+    color: transparent;
+  }
+
+  @media (max-width: 560px) {
+    .lk-code-editor,
+    .lk-code-editor-highlight,
+    .lk-code-editor textarea {
+      min-height: 24rem;
+      font-size: 0.8rem;
+    }
+  }
+</style>

--- a/website/src/components/Playground.css
+++ b/website/src/components/Playground.css
@@ -1,0 +1,240 @@
+.playground-page {
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: clamp(4rem, 9vw, 7rem) 0 clamp(3rem, 8vw, 6rem);
+}
+
+.playground-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 4vw, 3rem);
+  margin-bottom: 2rem;
+}
+
+.playground-heading p:last-child {
+  max-width: 38rem;
+  color: var(--ink-soft);
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  text-align: right;
+}
+
+.playground-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(19rem, 0.85fr);
+  min-height: 34rem;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--card-bg);
+  box-shadow: 0 22px 50px -34px var(--shadow-soft);
+}
+
+.playground-editor,
+.playground-output {
+  min-width: 0;
+}
+
+.playground-editor {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  border-right: 1px solid var(--line-soft);
+}
+
+.playground-toolbar,
+.output-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: 4.2rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--line-soft);
+}
+
+.playground-toolbar label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.playground-toolbar select {
+  min-width: 11rem;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+  appearance: none;
+  background:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%) calc(100% - 1.05rem) 50% / 0.42rem 0.42rem no-repeat,
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%) calc(100% - 0.78rem) 50% / 0.42rem 0.42rem no-repeat,
+    var(--surface);
+  color: var(--ink);
+  font: 600 0.95rem var(--font-sans);
+  padding: 0.55rem 2.1rem 0.55rem 0.7rem;
+}
+
+.playground-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.playground-actions .icon-btn,
+.playground-actions .btn {
+  min-height: 2.55rem;
+  height: 2.55rem;
+}
+
+.playground-actions .btn {
+  padding: 0 1rem;
+}
+
+.playground-output {
+  display: grid;
+  align-content: start;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  background:
+    linear-gradient(90deg, rgba(128, 128, 128, 0.04) 1px, transparent 1px),
+    var(--surface);
+  background-size: 28px 28px;
+}
+
+.output-header {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.playground-output h2 {
+  margin: 0 1rem -0.55rem;
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.playground-output pre {
+  margin: 0 1rem;
+  padding: 1rem;
+  overflow: auto;
+  border: 1px solid var(--code-border);
+  border-radius: var(--radius);
+  background: var(--code-bg);
+  color: var(--code-text);
+  font: 500 0.86rem/1.65 var(--font-mono);
+}
+
+.output-status,
+.output-empty {
+  margin: 1rem 1rem 0;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius);
+}
+
+.output-status {
+  font-weight: 700;
+}
+
+.output-empty {
+  display: grid;
+  gap: 0.45rem;
+  max-width: 32rem;
+  color: var(--ink-soft);
+  background: var(--card-bg-soft);
+}
+
+.output-empty span {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.output-empty p {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.output-ok {
+  border-color: var(--accent-border);
+  color: var(--accent-ink);
+}
+
+.output-fail,
+.output-error {
+  border-color: rgba(143, 59, 70, 0.36) !important;
+  color: var(--rose) !important;
+}
+
+.output-skeleton {
+  height: 5rem;
+  margin: 1rem 1rem 0;
+  border-radius: var(--radius);
+  background: linear-gradient(90deg, var(--surface-2), var(--surface-3), var(--surface-2));
+  background-size: 220% 100%;
+  animation: skeleton-slide 1.4s ease-in-out infinite;
+}
+
+.output-skeleton.short {
+  width: 64%;
+  height: 3rem;
+  margin-top: 0;
+}
+
+@keyframes skeleton-slide {
+  0% {
+    background-position: 110% 0;
+  }
+  100% {
+    background-position: -110% 0;
+  }
+}
+
+@media (max-width: 860px) {
+  .playground-heading,
+  .playground-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .playground-editor {
+    border-right: 0;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .playground-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .playground-heading p:last-child {
+    text-align: left;
+  }
+}
+
+@media (max-width: 560px) {
+  .playground-page {
+    width: min(100% - 24px, 1180px);
+  }
+
+  .playground-toolbar,
+  .output-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .playground-toolbar select,
+  .playground-toolbar label,
+  .playground-actions,
+  .playground-actions .btn {
+    width: 100%;
+  }
+
+  .playground-actions {
+    display: grid;
+    grid-template-columns: auto 1fr;
+  }
+}

--- a/website/src/components/Playground.svelte
+++ b/website/src/components/Playground.svelte
@@ -62,7 +62,32 @@
 
   async function copyOutput(): Promise<void> {
     const text = [result?.stdout, result?.result, result?.error].filter(Boolean).join('\n')
-    if (text) await navigator.clipboard.writeText(text)
+    if (!text) return
+
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text)
+        return
+      }
+    } catch (error) {
+      console.warn('Clipboard API copy failed; falling back to document copy.', error)
+    }
+
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    textarea.style.top = '0'
+    document.body.appendChild(textarea)
+    textarea.select()
+    try {
+      document.execCommand('copy')
+    } catch (error) {
+      console.warn('Fallback clipboard copy failed.', error)
+    } finally {
+      document.body.removeChild(textarea)
+    }
   }
 </script>
 

--- a/website/src/components/Playground.svelte
+++ b/website/src/components/Playground.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { Copy, Play, RotateCcw } from '@lucide/svelte'
+  import './Playground.css'
+  import LkCodeEditor from './LkCodeEditor.svelte'
+  import { loadLkWasm, type RunResult } from '../lib/lkWasm'
+  import { playgroundExamples } from '../lib/playgroundExamples'
+
+  let source = playgroundExamples[0].code
+  let activeExample = playgroundExamples[0].name
+  let wasmReady = false
+  let loading = true
+  let running = false
+  let loadError = ''
+  let result: RunResult | undefined = undefined
+
+  onMount(async () => {
+    try {
+      await loadLkWasm()
+      wasmReady = true
+    } catch (error) {
+      loadError = error instanceof Error ? error.message : String(error)
+    } finally {
+      loading = false
+    }
+  })
+
+  async function run(): Promise<void> {
+    running = true
+    result = undefined
+    try {
+      const wasm = await loadLkWasm()
+      result = wasm.runLk(source)
+    } catch (error) {
+      result = {
+        ok: false,
+        stdout: '',
+        result: null,
+        error: error instanceof Error ? error.message : String(error),
+        diagnostics: [],
+        elapsedMs: 0,
+      }
+    } finally {
+      running = false
+    }
+  }
+
+  function reset(): void {
+    const current = playgroundExamples.find((example) => example.name === activeExample) || playgroundExamples[0]
+    source = current.code
+    result = undefined
+  }
+
+  function selectExample(event: Event): void {
+    const name = (event.currentTarget as HTMLSelectElement).value
+    const example = playgroundExamples.find((item) => item.name === name)
+    if (!example) return
+    activeExample = example.name
+    source = example.code
+    result = undefined
+  }
+
+  async function copyOutput(): Promise<void> {
+    const text = [result?.stdout, result?.result, result?.error].filter(Boolean).join('\n')
+    if (text) await navigator.clipboard.writeText(text)
+  }
+</script>
+
+<section class="playground-page" aria-labelledby="try-title">
+  <div class="playground-heading">
+    <p id="try-title" class="eyebrow">LK Wasm Playground</p>
+    <p>
+      The playground loads the LK wasm runtime only on this page and runs a browser-safe stdlib subset.
+    </p>
+  </div>
+
+  <div class="playground-shell">
+    <section class="playground-editor" aria-label="LK source editor">
+      <div class="playground-toolbar">
+        <label>
+          <span>Example</span>
+          <select value={activeExample} on:change={selectExample}>
+            {#each playgroundExamples as example}
+              <option value={example.name}>{example.name}</option>
+            {/each}
+          </select>
+        </label>
+        <div class="playground-actions">
+          <button class="icon-btn" type="button" on:click={reset} aria-label="Reset source">
+            <RotateCcw size={17} />
+          </button>
+          <button class="btn btn-primary" type="button" on:click={run} disabled={!wasmReady || running}>
+            <Play size={18} />
+            {running ? 'Running' : 'Run'}
+          </button>
+        </div>
+      </div>
+      <LkCodeEditor bind:value={source} ariaLabel="LK source code" />
+    </section>
+
+    <section class="playground-output" aria-label="Run output">
+      <div class="output-header">
+        <span>{loading ? 'Loading wasm' : wasmReady ? 'Ready' : 'Unavailable'}</span>
+        <button class="icon-btn" type="button" on:click={copyOutput} disabled={!result} aria-label="Copy output">
+          <Copy size={17} />
+        </button>
+      </div>
+
+      {#if loadError}
+        <pre class="output-error">{loadError}</pre>
+      {:else if loading}
+        <div class="output-skeleton"></div>
+        <div class="output-skeleton short"></div>
+      {:else if result}
+        <div class:output-ok={result.ok} class:output-fail={!result.ok} class="output-status">
+          {result.ok ? 'Completed' : 'Failed'} · {result.elapsedMs.toFixed(1)} ms
+        </div>
+        {#if result.stdout}
+          <h2>stdout</h2>
+          <pre>{result.stdout}</pre>
+        {/if}
+        {#if result.result}
+          <h2>result</h2>
+          <pre>{result.result}</pre>
+        {/if}
+        {#if result.error}
+          <h2>error</h2>
+          <pre class="output-error">{result.error}</pre>
+        {/if}
+        {#each result.diagnostics as diagnostic}
+          {#if diagnostic.rendered}
+            <h2>{diagnostic.level}</h2>
+            <pre class="output-error">{diagnostic.rendered}</pre>
+          {/if}
+        {/each}
+      {:else}
+        <div class="output-empty">
+          <span>Ready</span>
+          <p>Select an example or edit the source, then run it in the wasm sandbox.</p>
+        </div>
+      {/if}
+    </section>
+  </div>
+</section>

--- a/website/src/i18n/en/index.ts
+++ b/website/src/i18n/en/index.ts
@@ -8,6 +8,7 @@ const en: BaseTranslation = {
       'LK is a Rust-like scripting language with rich pattern matching, package uses, practical CLI workflows, and a batteries-included standard library.',
   },
   nav: {
+    try: 'Try',
     spec: 'Spec',
     github: 'Github',
     languageLabel: 'Language',

--- a/website/src/i18n/i18n-types.ts
+++ b/website/src/i18n/i18n-types.ts
@@ -30,6 +30,10 @@ type RootTranslation = {
 	}
 	nav: {
 		/**
+		 * T​r​y
+		 */
+		'try': string
+		/**
 		 * S​p​e​c
 		 */
 		spec: string
@@ -248,6 +252,10 @@ export type TranslationFunctions = {
 		description: () => LocalizedString
 	}
 	nav: {
+		/**
+		 * Try
+		 */
+		'try': () => LocalizedString
 		/**
 		 * Spec
 		 */

--- a/website/src/i18n/zh-CN/index.ts
+++ b/website/src/i18n/zh-CN/index.ts
@@ -7,6 +7,7 @@ const zhCN: Translation = {
     description: 'LK 是 Rust 编写的 Rust 风格轻量脚本语言，包含丰富语法糖、结构化模式匹配、package use 和实用标准库',
   },
   nav: {
+    try: '试用',
     spec: '规范',
     github: 'Github',
     languageLabel: '语言',

--- a/website/src/lib/highlight.ts
+++ b/website/src/lib/highlight.ts
@@ -1,0 +1,194 @@
+const lkKeywords = new Set([
+  'if',
+  'else',
+  'while',
+  'for',
+  'in',
+  'match',
+  'return',
+  'break',
+  'continue',
+  'select',
+  'case',
+  'default',
+  'let',
+  'const',
+  'fn',
+  'struct',
+  'trait',
+  'impl',
+  'use',
+  'from',
+  'as',
+  'spawn',
+  'chan',
+  'send',
+  'recv',
+])
+
+const lkTypes = new Set([
+  'Int',
+  'Float',
+  'String',
+  'Bool',
+  'Nil',
+  'Any',
+  'List',
+  'Map',
+  'Task',
+  'Channel',
+  'Function',
+  'Object',
+  'Stream',
+  'StreamCursor',
+  'Iterator',
+  'MutationGuard',
+])
+
+const lkConstants = new Set(['true', 'false', 'nil'])
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function wrapToken(kind: string, value: string): string {
+  return `<span class="lk-token lk-${kind}">${escapeHtml(value)}</span>`
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return !!char && /[A-Za-z_]/.test(char)
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return !!char && /[A-Za-z0-9_-]/.test(char)
+}
+
+function readQuotedString(source: string, start: number, quote: string): number {
+  let index = start + 1
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2
+      continue
+    }
+    if (source[index] === quote) return index + 1
+    index += 1
+  }
+  return source.length
+}
+
+function readRawString(source: string, start: number): number | undefined {
+  const opener = source.slice(start).match(/^r(#+)?"/)
+  if (!opener) return undefined
+
+  const hashes = opener[1] || ''
+  const close = `"${hashes}`
+  const contentStart = start + opener[0].length
+  const closeIndex = source.indexOf(close, contentStart)
+  return closeIndex === -1 ? source.length : closeIndex + close.length
+}
+
+export function highlightLkCode(source: string): string {
+  let html = ''
+  let index = 0
+  let inBlockComment = false
+
+  while (index < source.length) {
+    if (inBlockComment) {
+      const end = source.indexOf('*/', index)
+      const nextIndex = end === -1 ? source.length : end + 2
+      html += wrapToken('comment', source.slice(index, nextIndex))
+      index = nextIndex
+      inBlockComment = end === -1
+      continue
+    }
+
+    const char = source[index]
+    const next = source[index + 1]
+
+    if (char === '/' && next === '*') {
+      const end = source.indexOf('*/', index + 2)
+      const nextIndex = end === -1 ? source.length : end + 2
+      html += wrapToken('comment', source.slice(index, nextIndex))
+      index = nextIndex
+      inBlockComment = end === -1
+      continue
+    }
+
+    if (char === '/' && next === '/') {
+      const end = source.indexOf('\n', index)
+      const nextIndex = end === -1 ? source.length : end
+      html += wrapToken('comment', source.slice(index, nextIndex))
+      index = nextIndex
+      continue
+    }
+
+    const rawStringEnd = char === 'r' ? readRawString(source, index) : undefined
+    if (rawStringEnd !== undefined) {
+      html += wrapToken('string', source.slice(index, rawStringEnd))
+      index = rawStringEnd
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      const end = readQuotedString(source, index, char)
+      html += wrapToken('string', source.slice(index, end))
+      index = end
+      continue
+    }
+
+    if (/\d/.test(char)) {
+      const match = source.slice(index).match(/^\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/)
+      if (match) {
+        html += wrapToken('number', match[0])
+        index += match[0].length
+        continue
+      }
+    }
+
+    if (isIdentifierStart(char)) {
+      let end = index + 1
+      while (isIdentifierPart(source[end])) end += 1
+      const word = source.slice(index, end)
+      const rest = source.slice(end).replace(/^\s+/, '')
+
+      if (lkConstants.has(word)) {
+        html += wrapToken('constant', word)
+      } else if (lkTypes.has(word)) {
+        html += wrapToken('type', word)
+      } else if (lkKeywords.has(word)) {
+        html += wrapToken('keyword', word)
+      } else if (rest.startsWith('(')) {
+        html += wrapToken('function', word)
+      } else {
+        html += escapeHtml(word)
+      }
+      index = end
+      continue
+    }
+
+    const operator = source
+      .slice(index)
+      .match(/^(?:\?\?|\?\.|\?\[|=>|->|\.\.=|\.\.|==|!=|<=|>=|\+=|-=|\*=|\/=|%=|&&|\|\||:=|[+\-*/%&|~!?:=<>])/)
+    if (operator) {
+      html += wrapToken('operator', operator[0])
+      index += operator[0].length
+      continue
+    }
+
+    if (/[\[\]{}().,;]/.test(char)) {
+      html += wrapToken('punctuation', char)
+      index += 1
+      continue
+    }
+
+    html += escapeHtml(char)
+    index += 1
+  }
+
+  return html
+}

--- a/website/src/lib/highlight.ts
+++ b/website/src/lib/highlight.ts
@@ -154,7 +154,9 @@ export function highlightLkCode(source: string): string {
       let end = index + 1
       while (isIdentifierPart(source[end])) end += 1
       const word = source.slice(index, end)
-      const rest = source.slice(end).replace(/^\s+/, '')
+      let nextIndex = end
+      while (/\s/.test(source[nextIndex] || '')) nextIndex += 1
+      const nextChar = source[nextIndex]
 
       if (lkConstants.has(word)) {
         html += wrapToken('constant', word)
@@ -162,7 +164,7 @@ export function highlightLkCode(source: string): string {
         html += wrapToken('type', word)
       } else if (lkKeywords.has(word)) {
         html += wrapToken('keyword', word)
-      } else if (rest.startsWith('(')) {
+      } else if (nextChar === '(') {
         html += wrapToken('function', word)
       } else {
         html += escapeHtml(word)

--- a/website/src/lib/lkWasm.ts
+++ b/website/src/lib/lkWasm.ts
@@ -1,0 +1,32 @@
+export type Diagnostic = {
+  level: 'error' | 'warning'
+  message: string
+  rendered?: string
+  line?: number
+  column?: number
+}
+
+export type RunResult = {
+  ok: boolean
+  stdout: string
+  result: string | null
+  error: string | null
+  diagnostics: Diagnostic[]
+  elapsedMs: number
+}
+
+type LkWasmModule = {
+  default: () => Promise<void>
+  runLk: (source: string) => RunResult
+}
+
+let modulePromise: Promise<LkWasmModule> | undefined
+
+export async function loadLkWasm(): Promise<LkWasmModule> {
+  modulePromise ??= import('../wasm/pkg/lk_wasm.js').then(async (mod) => {
+    const wasm = mod as LkWasmModule
+    await wasm.default()
+    return wasm
+  })
+  return modulePromise
+}

--- a/website/src/lib/lkWasm.ts
+++ b/website/src/lib/lkWasm.ts
@@ -16,17 +16,22 @@ export type RunResult = {
 }
 
 type LkWasmModule = {
-  default: () => Promise<void>
+  default: () => Promise<unknown>
   runLk: (source: string) => RunResult
 }
 
 let modulePromise: Promise<LkWasmModule> | undefined
 
 export async function loadLkWasm(): Promise<LkWasmModule> {
-  modulePromise ??= import('../wasm/pkg/lk_wasm.js').then(async (mod) => {
-    const wasm = mod as LkWasmModule
-    await wasm.default()
-    return wasm
-  })
+  modulePromise ??= import('../wasm/pkg/lk_wasm.js')
+    .then(async (mod) => {
+      const wasm = mod as LkWasmModule
+      await wasm.default()
+      return wasm
+    })
+    .catch((error) => {
+      modulePromise = undefined
+      throw error
+    })
   return modulePromise
 }

--- a/website/src/lib/playgroundExamples.ts
+++ b/website/src/lib/playgroundExamples.ts
@@ -1,0 +1,120 @@
+export type PlaygroundExample = {
+  name: string
+  code: string
+  expectFailure?: boolean
+}
+
+export const playgroundExamples: PlaygroundExample[] = [
+  {
+    name: 'Pattern match',
+    code: `let status = 404;
+let label = match status {
+  200 => "OK",
+  301 | 302 => "Redirect",
+  404 => "Not Found",
+  _ => "Unknown",
+};
+
+println("status {}: {}", status, label);
+return label;`,
+  },
+  {
+    name: 'Destructuring',
+    code: `let user = { "name": "Mira", "roles": ["admin", "editor"], "active": true };
+let { "name": name, "roles": [primary, ..rest] } = user;
+
+if let [next, .._] = rest {
+  println("{} handles {} then {}", name, primary, next);
+}
+
+return "\${name}:\${primary}:\${rest.len()}";`,
+  },
+  {
+    name: 'Struct traits',
+    code: `struct Rect { w: Int, h: Int }
+
+trait Area {
+  fn area(self) -> Int;
+}
+
+trait Describe {
+  fn describe(self) -> String;
+}
+
+impl Area for Rect {
+  fn area(self) -> Int { return self.w * self.h; }
+}
+
+impl Describe for Rect {
+  fn describe(self) -> String { return "Rect(\${self.w}x\${self.h})"; }
+}
+
+let shape = Rect { w: 8, h: 5 };
+println("{} area={}", shape.describe(), shape.area());
+return shape.area();`,
+  },
+  {
+    name: 'Named params',
+    code: `fn range_sum(start, stop, { step: Int? = 1, label: String? = "sum" }) {
+  let acc = 0;
+  let i = start;
+  let step_val = step ?? 1;
+  let label_text = label ?? "sum";
+
+  while (i <= stop) {
+    acc += i;
+    i += step_val;
+  }
+
+  println("{}: {}", label_text, acc);
+  return acc;
+}
+
+return range_sum(0, 8, label: "evens", step: 2);`,
+  },
+  {
+    name: 'Collections',
+    code: `let scores = [9, 12, 7, 12];
+scores.push(15);
+
+let profile = { "name": "Iris", "scores": scores };
+let best = profile.scores.sort().reverse()[0];
+let unique = profile.scores.unique();
+
+println("{} best={} unique={}", profile.name, best, unique.len());
+return best;`,
+  },
+  {
+    name: 'Ranges',
+    code: `use iter;
+
+let inclusive = 1..=5;
+let stepped = iter.range(0, 10, 2);
+let total = 0;
+
+for value in inclusive {
+  total += value;
+}
+
+println("range total={}, stepped={}", total, stepped);
+return total + stepped.len();`,
+  },
+  {
+    name: 'Iter pipeline',
+    code: `use iter;
+
+let values = iter.range(1, 8);
+let doubled = iter.map(values, |value| value * 2);
+let large = iter.filter(doubled, |value| value > 8);
+let total = iter.reduce(large, 0, |acc, value| acc + value);
+
+println("total = {}", total);
+return total;`,
+  },
+  {
+    name: 'Browser guard',
+    code: `use fs;
+println("this line will not run");`,
+    expectFailure: true,
+  },
+]

--- a/website/src/main.ts
+++ b/website/src/main.ts
@@ -1,4 +1,5 @@
 import './app.css'
+import './syntax.css'
 import App from './App.svelte'
 import { mount } from 'svelte'
 

--- a/website/src/syntax.css
+++ b/website/src/syntax.css
@@ -1,0 +1,39 @@
+.lk-keyword {
+  color: var(--syntax-keyword);
+  font-weight: 600;
+}
+
+.lk-function {
+  color: var(--syntax-function);
+}
+
+.lk-string {
+  color: var(--syntax-string);
+}
+
+.lk-number {
+  color: var(--syntax-number);
+}
+
+.lk-constant {
+  color: var(--syntax-constant);
+  font-weight: 600;
+}
+
+.lk-type {
+  color: var(--syntax-type);
+  font-weight: 600;
+}
+
+.lk-operator {
+  color: var(--syntax-operator);
+}
+
+.lk-punctuation {
+  color: var(--syntax-punctuation);
+}
+
+.lk-comment {
+  color: var(--syntax-comment);
+  font-style: italic;
+}

--- a/website/src/wasm/pkg/lk_wasm.d.ts
+++ b/website/src/wasm/pkg/lk_wasm.d.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+
+export function runLk(source: string): any;
+
+export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+
+export interface InitOutput {
+    readonly memory: WebAssembly.Memory;
+    readonly runLk: (a: number, b: number) => any;
+    readonly __wbindgen_malloc: (a: number, b: number) => number;
+    readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
+    readonly __wbindgen_externrefs: WebAssembly.Table;
+    readonly __wbindgen_start: () => void;
+}
+
+export type SyncInitInput = BufferSource | WebAssembly.Module;
+
+/**
+ * Instantiates the given `module`, which can either be bytes or
+ * a precompiled `WebAssembly.Module`.
+ *
+ * @param {{ module: SyncInitInput }} module - Passing `SyncInitInput` directly is deprecated.
+ *
+ * @returns {InitOutput}
+ */
+export function initSync(module: { module: SyncInitInput } | SyncInitInput): InitOutput;
+
+/**
+ * If `module_or_path` is {RequestInfo} or {URL}, makes a request and
+ * for everything else, calls `WebAssembly.instantiate` directly.
+ *
+ * @param {{ module_or_path: InitInput | Promise<InitInput> }} module_or_path - Passing `InitInput` directly is deprecated.
+ *
+ * @returns {Promise<InitOutput>}
+ */
+export default function __wbg_init (module_or_path?: { module_or_path: InitInput | Promise<InitInput> } | InitInput | Promise<InitInput>): Promise<InitOutput>;

--- a/website/src/wasm/pkg/lk_wasm.js
+++ b/website/src/wasm/pkg/lk_wasm.js
@@ -1,0 +1,313 @@
+/* @ts-self-types="./lk_wasm.d.ts" */
+
+/**
+ * @param {string} source
+ * @returns {any}
+ */
+export function runLk(source) {
+    const ptr0 = passStringToWasm0(source, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len0 = WASM_VECTOR_LEN;
+    const ret = wasm.runLk(ptr0, len0);
+    return ret;
+}
+function __wbg_get_imports() {
+    const import0 = {
+        __proto__: null,
+        __wbg___wbindgen_debug_string_edece8177ad01481: function(arg0, arg1) {
+            const ret = debugString(arg1);
+            const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+            const len1 = WASM_VECTOR_LEN;
+            getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+            getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+        },
+        __wbg___wbindgen_throw_9c31b086c2b26051: function(arg0, arg1) {
+            throw new Error(getStringFromWasm0(arg0, arg1));
+        },
+        __wbg_new_02d162bc6cf02f60: function() {
+            const ret = new Object();
+            return ret;
+        },
+        __wbg_new_310879b66b6e95e1: function() {
+            const ret = new Array();
+            return ret;
+        },
+        __wbg_now_81363d44c96dd239: function() {
+            const ret = Date.now();
+            return ret;
+        },
+        __wbg_set_6be42768c690e380: function(arg0, arg1, arg2) {
+            arg0[arg1] = arg2;
+        },
+        __wbg_set_78ea6a19f4818587: function(arg0, arg1, arg2) {
+            arg0[arg1 >>> 0] = arg2;
+        },
+        __wbindgen_cast_0000000000000001: function(arg0) {
+            // Cast intrinsic for `F64 -> Externref`.
+            const ret = arg0;
+            return ret;
+        },
+        __wbindgen_cast_0000000000000002: function(arg0, arg1) {
+            // Cast intrinsic for `Ref(String) -> Externref`.
+            const ret = getStringFromWasm0(arg0, arg1);
+            return ret;
+        },
+        __wbindgen_init_externref_table: function() {
+            const table = wasm.__wbindgen_externrefs;
+            const offset = table.grow(4);
+            table.set(0, undefined);
+            table.set(offset + 0, undefined);
+            table.set(offset + 1, null);
+            table.set(offset + 2, true);
+            table.set(offset + 3, false);
+        },
+    };
+    return {
+        __proto__: null,
+        "./lk_wasm_bg.js": import0,
+    };
+}
+
+function debugString(val) {
+    // primitive types
+    const type = typeof val;
+    if (type == 'number' || type == 'boolean' || val == null) {
+        return  `${val}`;
+    }
+    if (type == 'string') {
+        return `"${val}"`;
+    }
+    if (type == 'symbol') {
+        const description = val.description;
+        if (description == null) {
+            return 'Symbol';
+        } else {
+            return `Symbol(${description})`;
+        }
+    }
+    if (type == 'function') {
+        const name = val.name;
+        if (typeof name == 'string' && name.length > 0) {
+            return `Function(${name})`;
+        } else {
+            return 'Function';
+        }
+    }
+    // objects
+    if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = '[';
+        if (length > 0) {
+            debug += debugString(val[0]);
+        }
+        for(let i = 1; i < length; i++) {
+            debug += ', ' + debugString(val[i]);
+        }
+        debug += ']';
+        return debug;
+    }
+    // Test for built-in
+    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+    let className;
+    if (builtInMatches && builtInMatches.length > 1) {
+        className = builtInMatches[1];
+    } else {
+        // Failed to match the standard '[object ClassName]'
+        return toString.call(val);
+    }
+    if (className == 'Object') {
+        // we're a user defined class or Object
+        // JSON.stringify avoids problems with cycles, and is generally much
+        // easier than looping through ownProperties of `val`.
+        try {
+            return 'Object(' + JSON.stringify(val) + ')';
+        } catch (_) {
+            return 'Object';
+        }
+    }
+    // errors
+    if (val instanceof Error) {
+        return `${val.name}: ${val.message}\n${val.stack}`;
+    }
+    // TODO we could test for more things here, like `Set`s and `Map`s.
+    return className;
+}
+
+let cachedDataViewMemory0 = null;
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    return decodeText(ptr >>> 0, len);
+}
+
+let cachedUint8ArrayMemory0 = null;
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function passStringToWasm0(arg, malloc, realloc) {
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = cachedTextEncoder.encodeInto(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+cachedTextDecoder.decode();
+const MAX_SAFARI_DECODE_BYTES = 2146435072;
+let numBytesDecoded = 0;
+function decodeText(ptr, len) {
+    numBytesDecoded += len;
+    if (numBytesDecoded >= MAX_SAFARI_DECODE_BYTES) {
+        cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+        cachedTextDecoder.decode();
+        numBytesDecoded = len;
+    }
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const cachedTextEncoder = new TextEncoder();
+
+if (!('encodeInto' in cachedTextEncoder)) {
+    cachedTextEncoder.encodeInto = function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+            read: arg.length,
+            written: buf.length
+        };
+    };
+}
+
+let WASM_VECTOR_LEN = 0;
+
+let wasmModule, wasmInstance, wasm;
+function __wbg_finalize_init(instance, module) {
+    wasmInstance = instance;
+    wasm = instance.exports;
+    wasmModule = module;
+    cachedDataViewMemory0 = null;
+    cachedUint8ArrayMemory0 = null;
+    wasm.__wbindgen_start();
+    return wasm;
+}
+
+async function __wbg_load(module, imports) {
+    if (typeof Response === 'function' && module instanceof Response) {
+        if (typeof WebAssembly.instantiateStreaming === 'function') {
+            try {
+                return await WebAssembly.instantiateStreaming(module, imports);
+            } catch (e) {
+                const validResponse = module.ok && expectedResponseType(module.type);
+
+                if (validResponse && module.headers.get('Content-Type') !== 'application/wasm') {
+                    console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve Wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+
+                } else { throw e; }
+            }
+        }
+
+        const bytes = await module.arrayBuffer();
+        return await WebAssembly.instantiate(bytes, imports);
+    } else {
+        const instance = await WebAssembly.instantiate(module, imports);
+
+        if (instance instanceof WebAssembly.Instance) {
+            return { instance, module };
+        } else {
+            return instance;
+        }
+    }
+
+    function expectedResponseType(type) {
+        switch (type) {
+            case 'basic': case 'cors': case 'default': return true;
+        }
+        return false;
+    }
+}
+
+function initSync(module) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module !== undefined) {
+        if (Object.getPrototypeOf(module) === Object.prototype) {
+            ({module} = module)
+        } else {
+            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+        }
+    }
+
+    const imports = __wbg_get_imports();
+    if (!(module instanceof WebAssembly.Module)) {
+        module = new WebAssembly.Module(module);
+    }
+    const instance = new WebAssembly.Instance(module, imports);
+    return __wbg_finalize_init(instance, module);
+}
+
+async function __wbg_init(module_or_path) {
+    if (wasm !== undefined) return wasm;
+
+
+    if (module_or_path !== undefined) {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
+
+    if (module_or_path === undefined) {
+        module_or_path = new URL('lk_wasm_bg.wasm', import.meta.url);
+    }
+    const imports = __wbg_get_imports();
+
+    if (typeof module_or_path === 'string' || (typeof Request === 'function' && module_or_path instanceof Request) || (typeof URL === 'function' && module_or_path instanceof URL)) {
+        module_or_path = fetch(module_or_path);
+    }
+
+    const { instance, module } = await __wbg_load(await module_or_path, imports);
+
+    return __wbg_finalize_init(instance, module);
+}
+
+export { initSync, __wbg_init as default };

--- a/website/src/wasm/pkg/lk_wasm_bg.wasm
+++ b/website/src/wasm/pkg/lk_wasm_bg.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eed237604d239acf8809b981a77f9e533b2074e847602cde168da3bcb0dc273
+size 2653975

--- a/website/src/wasm/pkg/lk_wasm_bg.wasm.d.ts
+++ b/website/src/wasm/pkg/lk_wasm_bg.wasm.d.ts
@@ -1,0 +1,8 @@
+/* tslint:disable */
+/* eslint-disable */
+export const memory: WebAssembly.Memory;
+export const runLk: (a: number, b: number) => any;
+export const __wbindgen_malloc: (a: number, b: number) => number;
+export const __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
+export const __wbindgen_externrefs: WebAssembly.Table;
+export const __wbindgen_start: () => void;

--- a/website/src/wasm/pkg/package.json
+++ b/website/src/wasm/pkg/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lk-wasm",
+  "type": "module",
+  "collaborators": [
+    "lollipopkit <a@lpkt.cn>"
+  ],
+  "description": "Wasm facade for LK browser playground",
+  "version": "0.1.3",
+  "license": "Apache-2.0",
+  "files": [
+    "lk_wasm_bg.wasm",
+    "lk_wasm.js",
+    "lk_wasm.d.ts"
+  ],
+  "main": "lk_wasm.js",
+  "types": "lk_wasm.d.ts",
+  "sideEffects": [
+    "./snippets/*"
+  ]
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,6 +5,5 @@
     "checkJs": true,
     "moduleResolution": "bundler"
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
-  "exclude": ["src/wasm/pkg/**/*.js"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
 }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,5 +5,6 @@
     "checkJs": true,
     "moduleResolution": "bundler"
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"]
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "exclude": ["src/wasm/pkg/**/*.js"]
 }


### PR DESCRIPTION
## Summary
- add lk-wasm and browser-safe stdlib support for running LK in the website playground
- add lazy-loaded /try playground with highlighted editor, richer examples, and output diagnostics
- split playground frontend code/styles and document wasm/browser trial support

## Verification
- cargo test -p lk-wasm
- cargo test -p lk-stdlib-web -p lk-wasm
- cargo check -p lk-wasm --target wasm32-unknown-unknown
- cd website && bun run build
- playgroundExamples smoke via website/src/wasm/pkg runLk
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 在官网新增基于 WebAssembly 的浏览器 Playground：在线编辑并执行 LK 代码，展示 stdout、返回值、诊断与耗时，并支持复制输出
  * 新增可嵌入的代码编辑器组件与轻量语法高亮
  * 暴露 wasm 运行入口供前端调用（runLk）
  * 引入指令步数预算以限制执行时间
  * 提供浏览器安全的标准库子集并在不可用时给出友好提示

* **Documentation**
  * README 与官网文档补充 Playground 使用与本地/构建流程说明

* **Chores**
  * 新增构建脚本、包与构建配置及相关忽略/属性规则
<!-- end of auto-generated comment: release notes by coderabbit.ai -->