### PR TITLE
fix: improve LK LSP strict type inference

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,16 +7,16 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in library 'lkr-core'",
+            "name": "Debug unit tests in library 'lk-core'",
             "cargo": {
                 "args": [
                     "test",
                     "--no-run",
                     "--lib",
-                    "--package=lkr-core"
+                    "--package=lk-core"
                 ],
                 "filter": {
-                    "name": "lkr-core",
+                    "name": "lk-core",
                     "kind": "lib"
                 }
             },
@@ -28,28 +28,28 @@
             "type": "extensionHost",
             "request": "launch",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}/vsc-ext"
+                "--extensionDevelopmentPath=${workspaceFolder}/vsc-ext/lsp"
             ],
             "outFiles": [
-                "${workspaceFolder}/vsc-ext/out/**/*.js"
+                "${workspaceFolder}/vsc-ext/lsp/out/**/*.js"
             ],
             "preLaunchTask": "Build All"
         },
         {
-            "name": "Debug LKR LSP Server",
+            "name": "Debug LK LSP Server",
             "type": "lldb",
             "request": "launch",
             "cargo": {
                 "args": [
                     "build",
-                    "--package=lkr-lsp"
+                    "--package=lk-lsp"
                 ],
                 "filter": {
-                    "name": "lkr-lsp",
+                    "name": "lk-lsp",
                     "kind": "bin"
                 }
             },
-            "program": "${workspaceFolder}/target/debug/lkr-lsp",
+            "program": "${workspaceFolder}/target/debug/lk-lsp",
             "args": [],
             "cwd": "${workspaceFolder}"
         }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
                 "compile"
             ],
             "options": {
-                "cwd": "${workspaceFolder}/vsc-ext"
+                "cwd": "${workspaceFolder}/vsc-ext/lsp"
             },
             "group": {
                 "kind": "build"
@@ -18,13 +18,13 @@
             "problemMatcher": ["$tsc"]
         },
         {
-            "label": "Build LKR LSP Server",
+            "label": "Build LK LSP Server",
             "type": "shell",
             "command": "cargo",
             "args": [
                 "build",
                 "-p",
-                "lkr-lsp"
+                "lk-lsp"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -35,7 +35,7 @@
         {
             "label": "Build All",
             "dependsOn": [
-                "Build LKR LSP Server",
+                "Build LK LSP Server",
                 "Build VS Code Extension"
             ],
             "group": {
@@ -51,7 +51,7 @@
                 "install"
             ],
             "options": {
-                "cwd": "${workspaceFolder}/vsc-ext"
+                "cwd": "${workspaceFolder}/vsc-ext/lsp"
             },
             "problemMatcher": []
         }

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -484,10 +484,12 @@ impl Stmt {
 
                 if type_checker.strict_any() {
                     let mut issues: Vec<String> = Vec::new();
+                    let mut first_param_name = None;
                     for (idx, param_name) in params.iter().enumerate() {
                         if !positional_origin[idx]
                             && TypeChecker::type_is_strict_any_unresolved(&resolved_positional[idx])
                         {
+                            first_param_name.get_or_insert_with(|| param_name.clone());
                             issues.push(format!("parameter '{}'", param_name));
                         }
                     }
@@ -495,6 +497,7 @@ impl Stmt {
                         if !named_origin[idx]
                             && TypeChecker::type_is_strict_any_unresolved(&resolved_named_annos[idx].ty)
                         {
+                            first_param_name.get_or_insert_with(|| np.name.clone());
                             issues.push(format!("named parameter '{}'", np.name));
                         }
                     }
@@ -502,11 +505,11 @@ impl Stmt {
                         issues.push("return type".to_string());
                     }
                     if !issues.is_empty() {
-                        return Err(anyhow!(format!(
-                            "Function '{}' infers implicit Any for {}; add explicit annotations",
+                        return Err(TypeChecker::implicit_any_type_err(
                             name,
-                            issues.join(", ")
-                        )));
+                            &issues,
+                            first_param_name.as_deref(),
+                        ));
                     }
                 }
 

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -2,7 +2,10 @@ use super::{ForPattern, Program, Stmt};
 use crate::{
     expr::Pattern,
     token::ParseError,
-    typ::{FunctionSig, NamedParamSig, StructDef, TraitDef, TypeAlias as AliasDef, TypeChecker},
+    typ::{
+        FunctionSig, NamedParamSig, PendingStrictFunction, PendingStrictParam, StructDef, TraitDef,
+        TypeAlias as AliasDef, TypeChecker,
+    },
     val::{FunctionNamedParamType, Type},
 };
 use anyhow::{Result, anyhow};
@@ -409,6 +412,52 @@ impl Stmt {
                     normalize_union(collected_returns)
                 };
 
+                if type_checker.defer_strict_function_checks() {
+                    let pending_positional = params
+                        .iter()
+                        .cloned()
+                        .zip(positional_tys.iter().cloned())
+                        .zip(positional_origin.iter().copied())
+                        .map(|((name, ty), annotated)| PendingStrictParam { name, ty, annotated })
+                        .collect();
+                    let pending_named = named_params
+                        .iter()
+                        .map(|param| param.name.clone())
+                        .zip(named_annos.iter().map(|param| param.ty.clone()))
+                        .zip(named_origin.iter().copied())
+                        .map(|((name, ty), annotated)| PendingStrictParam { name, ty, annotated })
+                        .collect();
+
+                    let final_func_type = Type::Function {
+                        params: positional_tys.clone(),
+                        named_params: named_annos.clone(),
+                        return_type: Box::new(inferred_return.clone()),
+                    };
+
+                    if let Some(self_ty) = type_checker.current_impl_self_type().cloned() {
+                        type_checker.add_method_sig(&self_ty, name, final_func_type.clone());
+                    }
+
+                    type_checker.add_local_type(name.clone(), final_func_type);
+                    type_checker.add_function_sig(
+                        name.clone(),
+                        FunctionSig {
+                            positional: positional_tys,
+                            named: named_sigs,
+                            return_type: Some(inferred_return.clone()),
+                        },
+                    );
+                    type_checker.add_pending_strict_function(PendingStrictFunction {
+                        name: name.clone(),
+                        positional: pending_positional,
+                        named: pending_named,
+                        return_type: inferred_return,
+                        return_annotated: return_was_annotated,
+                    });
+
+                    return Ok(());
+                }
+
                 let subs = type_checker.solve_constraints()?;
                 let resolved_positional: Vec<Type> = positional_tys
                     .into_iter()
@@ -433,23 +482,23 @@ impl Stmt {
 
                 let resolved_return = normalize_union(vec![type_checker.apply_substitutions(inferred_return, &subs)]);
 
-                fn type_is_unresolved(ty: &Type) -> bool {
-                    matches!(ty, Type::Any)
-                }
-
                 if type_checker.strict_any() {
                     let mut issues: Vec<String> = Vec::new();
                     for (idx, param_name) in params.iter().enumerate() {
-                        if !positional_origin[idx] && type_is_unresolved(&resolved_positional[idx]) {
+                        if !positional_origin[idx]
+                            && TypeChecker::type_is_strict_any_unresolved(&resolved_positional[idx])
+                        {
                             issues.push(format!("parameter '{}'", param_name));
                         }
                     }
                     for (idx, np) in named_params.iter().enumerate() {
-                        if !named_origin[idx] && type_is_unresolved(&resolved_named_annos[idx].ty) {
+                        if !named_origin[idx]
+                            && TypeChecker::type_is_strict_any_unresolved(&resolved_named_annos[idx].ty)
+                        {
                             issues.push(format!("named parameter '{}'", np.name));
                         }
                     }
-                    if !return_was_annotated && type_is_unresolved(&resolved_return) {
+                    if !return_was_annotated && TypeChecker::type_is_strict_any_unresolved(&resolved_return) {
                         issues.push("return type".to_string());
                     }
                     if !issues.is_empty() {
@@ -716,6 +765,18 @@ impl Stmt {
 impl Program {
     /// 类型检查程序
     pub fn type_check(&self, type_checker: &mut TypeChecker) -> Result<()> {
+        if type_checker.strict_any() {
+            let previous_defer = type_checker.begin_deferred_strict_function_checks();
+            let result = (|| {
+                for stmt in &self.statements {
+                    stmt.type_check(type_checker)?;
+                }
+                type_checker.finalize_deferred_strict_function_checks()
+            })();
+            type_checker.restore_deferred_strict_function_checks(previous_defer);
+            return result;
+        }
+
         for stmt in &self.statements {
             stmt.type_check(type_checker)?;
         }

--- a/core/src/stmt/stmt_test.rs
+++ b/core/src/stmt/stmt_test.rs
@@ -1061,9 +1061,8 @@ mod tests {
     fn test_strict_function_param_without_concrete_call_still_errors() {
         let program = parse_program(
             r#"
-            let workload_filter = os.env.get("LK_WORKLOAD_FILTER", "");
             fn should_run(name) {
-                return workload_filter == "" || workload_filter == name;
+                return true;
             }
         "#,
         );
@@ -1072,5 +1071,52 @@ mod tests {
             .type_check(&mut checker)
             .expect_err("unconstrained function parameter should still require annotation");
         assert!(err.to_string().contains("parameter 'name'"));
+        let type_error = err
+            .downcast_ref::<crate::typ::TypeError>()
+            .expect("strict implicit Any should use structured TypeError");
+        assert_eq!(type_error.function_name.as_deref(), Some("should_run"));
+        assert_eq!(type_error.parameter_name.as_deref(), Some("name"));
+    }
+
+    #[test]
+    fn test_strict_function_pending_checks_clear_after_error() {
+        let mut checker = TypeChecker::new_strict();
+        let bad = parse_program(
+            r#"
+            fn unresolved(name) {
+                return name;
+            }
+        "#,
+        );
+        assert!(bad.type_check(&mut checker).is_err());
+
+        let good = parse_program(
+            r#"
+            fn resolved(name) {
+                return name;
+            }
+            let value = resolved("ok");
+        "#,
+        );
+        assert!(
+            good.type_check(&mut checker).is_ok(),
+            "stale pending strict checks from the failed program must not leak into the next check"
+        );
+    }
+
+    #[test]
+    fn test_type_check_stdlib_env_and_math_signatures() {
+        let program = parse_program(
+            r#"
+            let filter = os.env.get("LK_WORKLOAD_FILTER", "");
+            let hi = math.max(1, 2);
+            let lo = math.min(1, 2);
+            let clamped_default = math.clamp(5);
+            let clamped_range = math.clamp(5, 0, 10);
+            let clamped_named = math.clamp(5, min: 0, max: 10);
+        "#,
+        );
+        let mut checker = TypeChecker::new_strict();
+        assert!(program.type_check(&mut checker).is_ok());
     }
 }

--- a/core/src/stmt/stmt_test.rs
+++ b/core/src/stmt/stmt_test.rs
@@ -1027,4 +1027,50 @@ mod tests {
         let mut checker = TypeChecker::new_strict();
         assert!(program.type_check(&mut checker).is_ok());
     }
+
+    #[test]
+    fn test_strict_function_param_infers_from_later_string_call() {
+        let program = parse_program(
+            r#"
+            let workload_filter = os.env.get("LK_WORKLOAD_FILTER", "");
+            fn should_run(name) {
+                return workload_filter == "" || workload_filter == name;
+            }
+            if should_run("gcd_batch") {
+                println("run");
+            }
+        "#,
+        );
+        let mut checker = TypeChecker::new_strict();
+        assert!(program.type_check(&mut checker).is_ok());
+        let ty = checker
+            .get_local_type("should_run")
+            .expect("function type should remain in checker");
+        match ty {
+            crate::val::Type::Function {
+                params, return_type, ..
+            } => {
+                assert_eq!(params, &vec![crate::val::Type::String]);
+                assert_eq!(return_type.as_ref(), &crate::val::Type::Bool);
+            }
+            other => panic!("expected function type, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_strict_function_param_without_concrete_call_still_errors() {
+        let program = parse_program(
+            r#"
+            let workload_filter = os.env.get("LK_WORKLOAD_FILTER", "");
+            fn should_run(name) {
+                return workload_filter == "" || workload_filter == name;
+            }
+        "#,
+        );
+        let mut checker = TypeChecker::new_strict();
+        let err = program
+            .type_check(&mut checker)
+            .expect_err("unconstrained function parameter should still require annotation");
+        assert!(err.to_string().contains("parameter 'name'"));
+    }
 }

--- a/core/src/typ/type_checker.rs
+++ b/core/src/typ/type_checker.rs
@@ -70,6 +70,10 @@ pub struct TypeChecker {
     impl_self_type: Option<Type>,
     /// Recorded method signatures keyed by (receiver_type, method_name)
     method_sigs: HashMap<(String, String), Type>,
+    /// Function strict-Any checks delayed until the whole program contributes call-site constraints.
+    pending_strict_functions: Vec<PendingStrictFunction>,
+    /// Program-level type checking enables this so later call sites can refine earlier function declarations.
+    defer_strict_function_checks: bool,
 }
 
 impl Default for TypeChecker {
@@ -124,6 +128,8 @@ impl TypeChecker {
             options,
             impl_self_type: None,
             method_sigs: HashMap::new(),
+            pending_strict_functions: Vec::new(),
+            defer_strict_function_checks: false,
         }
     }
 
@@ -267,6 +273,32 @@ impl TypeChecker {
         self.inference_engine.add_constraint(a, b);
     }
 
+    pub fn defer_strict_function_checks(&self) -> bool {
+        self.defer_strict_function_checks
+    }
+
+    pub fn begin_deferred_strict_function_checks(&mut self) -> bool {
+        let previous = self.defer_strict_function_checks;
+        self.defer_strict_function_checks = true;
+        previous
+    }
+
+    pub fn restore_deferred_strict_function_checks(&mut self, previous: bool) {
+        self.defer_strict_function_checks = previous;
+    }
+
+    pub fn add_pending_strict_function(&mut self, pending: PendingStrictFunction) {
+        self.pending_strict_functions.push(pending);
+    }
+
+    pub fn finalize_deferred_strict_function_checks(&mut self) -> Result<()> {
+        let subs = self.solve_constraints()?;
+        self.apply_substitutions_to_environment(&subs);
+        self.check_pending_strict_functions(&subs)?;
+        self.pending_strict_functions.clear();
+        Ok(())
+    }
+
     /// Get the inferred type for a local variable
     pub fn get_local_type(&self, name: &str) -> Option<&Type> {
         self.local_types.get(name)
@@ -319,6 +351,52 @@ impl TypeChecker {
             self.const_locals = prev;
         }
     }
+
+    fn apply_substitutions_to_environment(&mut self, subs: &HashMap<String, Type>) {
+        for ty in self.local_types.values_mut() {
+            *ty = ty.substitute(subs);
+        }
+        for sig in self.function_sigs.values_mut() {
+            sig.apply_substitutions(subs);
+        }
+        for ty in self.method_sigs.values_mut() {
+            *ty = ty.substitute(subs);
+        }
+    }
+
+    fn check_pending_strict_functions(&self, subs: &HashMap<String, Type>) -> Result<()> {
+        for pending in &self.pending_strict_functions {
+            let mut issues = Vec::new();
+            for param in &pending.positional {
+                let resolved = param.ty.substitute(subs);
+                if !param.annotated && Self::type_is_strict_any_unresolved(&resolved) {
+                    issues.push(format!("parameter '{}'", param.name));
+                }
+            }
+            for param in &pending.named {
+                let resolved = param.ty.substitute(subs);
+                if !param.annotated && Self::type_is_strict_any_unresolved(&resolved) {
+                    issues.push(format!("named parameter '{}'", param.name));
+                }
+            }
+            let resolved_return = pending.return_type.substitute(subs);
+            if !pending.return_annotated && Self::type_is_strict_any_unresolved(&resolved_return) {
+                issues.push("return type".to_string());
+            }
+            if !issues.is_empty() {
+                return Err(anyhow::anyhow!(format!(
+                    "Function '{}' infers implicit Any for {}; add explicit annotations",
+                    pending.name,
+                    issues.join(", ")
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn type_is_strict_any_unresolved(ty: &Type) -> bool {
+        matches!(ty, Type::Any) || ty.contains_variables()
+    }
 }
 
 /// Function signature for static checking (positional + named)
@@ -329,9 +407,39 @@ pub struct FunctionSig {
     pub return_type: Option<Type>,
 }
 
+impl FunctionSig {
+    fn apply_substitutions(&mut self, subs: &HashMap<String, Type>) {
+        for ty in &mut self.positional {
+            *ty = ty.substitute(subs);
+        }
+        for param in &mut self.named {
+            param.ty = param.ty.substitute(subs);
+        }
+        if let Some(return_type) = &mut self.return_type {
+            *return_type = return_type.substitute(subs);
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct NamedParamSig {
     pub name: String,
     pub ty: Type,
     pub has_default: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingStrictFunction {
+    pub name: String,
+    pub positional: Vec<PendingStrictParam>,
+    pub named: Vec<PendingStrictParam>,
+    pub return_type: Type,
+    pub return_annotated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PendingStrictParam {
+    pub name: String,
+    pub ty: Type,
+    pub annotated: bool,
 }

--- a/core/src/typ/type_checker.rs
+++ b/core/src/typ/type_checker.rs
@@ -32,6 +32,8 @@ pub struct TypeError {
     pub expected: Option<Type>,
     pub actual: Option<Type>,
     pub expr: Option<Expr>,
+    pub function_name: Option<String>,
+    pub parameter_name: Option<String>,
 }
 
 impl std::fmt::Display for TypeError {
@@ -89,8 +91,30 @@ impl TypeChecker {
             expected,
             actual,
             expr,
+            function_name: None,
+            parameter_name: None,
         };
         anyhow::Error::new(te)
+    }
+
+    pub fn implicit_any_type_err(
+        function_name: &str,
+        issues: &[String],
+        parameter_name: Option<&str>,
+    ) -> anyhow::Error {
+        let message = format!(
+            "Function '{}' infers implicit Any for {}; add explicit annotations",
+            function_name,
+            issues.join(", ")
+        );
+        anyhow::Error::new(TypeError {
+            message,
+            expected: None,
+            actual: None,
+            expr: None,
+            function_name: Some(function_name.to_string()),
+            parameter_name: parameter_name.map(str::to_string),
+        })
     }
     /// Create a new type checker with default (non-strict) behaviour
     pub fn new() -> Self {
@@ -292,11 +316,10 @@ impl TypeChecker {
     }
 
     pub fn finalize_deferred_strict_function_checks(&mut self) -> Result<()> {
+        let pending = std::mem::take(&mut self.pending_strict_functions);
         let subs = self.solve_constraints()?;
         self.apply_substitutions_to_environment(&subs);
-        self.check_pending_strict_functions(&subs)?;
-        self.pending_strict_functions.clear();
-        Ok(())
+        self.check_pending_strict_functions(&pending, &subs)
     }
 
     /// Get the inferred type for a local variable
@@ -364,18 +387,25 @@ impl TypeChecker {
         }
     }
 
-    fn check_pending_strict_functions(&self, subs: &HashMap<String, Type>) -> Result<()> {
-        for pending in &self.pending_strict_functions {
+    fn check_pending_strict_functions(
+        &self,
+        pending_functions: &[PendingStrictFunction],
+        subs: &HashMap<String, Type>,
+    ) -> Result<()> {
+        for pending in pending_functions {
             let mut issues = Vec::new();
+            let mut first_param_name = None;
             for param in &pending.positional {
                 let resolved = param.ty.substitute(subs);
                 if !param.annotated && Self::type_is_strict_any_unresolved(&resolved) {
+                    first_param_name.get_or_insert_with(|| param.name.clone());
                     issues.push(format!("parameter '{}'", param.name));
                 }
             }
             for param in &pending.named {
                 let resolved = param.ty.substitute(subs);
                 if !param.annotated && Self::type_is_strict_any_unresolved(&resolved) {
+                    first_param_name.get_or_insert_with(|| param.name.clone());
                     issues.push(format!("named parameter '{}'", param.name));
                 }
             }
@@ -384,11 +414,11 @@ impl TypeChecker {
                 issues.push("return type".to_string());
             }
             if !issues.is_empty() {
-                return Err(anyhow::anyhow!(format!(
-                    "Function '{}' infers implicit Any for {}; add explicit annotations",
-                    pending.name,
-                    issues.join(", ")
-                )));
+                return Err(Self::implicit_any_type_err(
+                    &pending.name,
+                    &issues,
+                    first_param_name.as_deref(),
+                ));
             }
         }
         Ok(())

--- a/core/src/typ/type_checker/expressions.rs
+++ b/core/src/typ/type_checker/expressions.rs
@@ -1,7 +1,9 @@
 mod calls;
+mod literals;
+mod stdlib;
 
 use super::{NamedParamSig, TypeChecker};
-use crate::expr::{Expr, SelectCase, SelectPattern, TemplateStringPart};
+use crate::expr::{Expr, SelectCase, SelectPattern};
 use crate::operator::{BinOp, UnaryOp};
 use crate::typ::{NumericClass, NumericHierarchy};
 use crate::val::{FunctionNamedParamType, LiteralVal, Type};
@@ -890,6 +892,10 @@ impl TypeChecker {
 
     /// Check access type (expr.field or expr[index])
     fn check_access(&mut self, expr: &Expr, field: &Expr) -> Result<Type> {
+        if let Some(function_type) = self.stdlib_access_function_type(expr, field) {
+            return Ok(function_type);
+        }
+
         let expr_type = self.check_expr(expr)?;
         let field_type = self.check_expr(field)?;
         let resolved_expr_type = self.resolve_aliases(&expr_type);
@@ -1487,50 +1493,5 @@ impl TypeChecker {
                 None,
             )
         })
-    }
-
-    /// Check template string type
-    fn check_template_string(&mut self, parts: &[TemplateStringPart]) -> Result<Type> {
-        // All parts must be string-coercible
-        for part in parts {
-            match part {
-                TemplateStringPart::Literal(_) => {
-                    // String literals are fine
-                }
-                TemplateStringPart::Expr(expr) => {
-                    let expr_type = self.check_expr(expr)?;
-                    // Allow implicit string coercion for template parts (adds constraint for vars)
-                    self.coerce_to_string(&expr_type);
-                }
-            }
-        }
-
-        Ok(Type::String)
-    }
-
-    /// Check literal value type
-    fn check_literal(&mut self, val: &LiteralVal) -> Result<Type> {
-        match val {
-            LiteralVal::Nil => Ok(Type::Nil),
-            LiteralVal::Bool(_) => Ok(Type::Bool),
-            LiteralVal::Int(_) => Ok(Type::Int),
-            LiteralVal::Float(_) => Ok(Type::Float),
-            LiteralVal::ShortStr(_) => Ok(Type::String),
-            value if value.as_str().is_some() => Ok(Type::String),
-            LiteralVal::String(_) => Ok(Type::String),
-        }
-    }
-
-    /// Infer type from a LiteralVal (for use in literal checking)
-    pub(super) fn infer_val_type(&mut self, val: &LiteralVal) -> Result<Type> {
-        match val {
-            LiteralVal::Nil => Ok(Type::Nil),
-            LiteralVal::Bool(_) => Ok(Type::Bool),
-            LiteralVal::Int(_) => Ok(Type::Int),
-            LiteralVal::Float(_) => Ok(Type::Float),
-            LiteralVal::ShortStr(_) => Ok(Type::String),
-            value if value.as_str().is_some() => Ok(Type::String),
-            LiteralVal::String(_) => Ok(Type::String),
-        }
     }
 }

--- a/core/src/typ/type_checker/expressions.rs
+++ b/core/src/typ/type_checker/expressions.rs
@@ -264,6 +264,9 @@ impl TypeChecker {
 
                     return Ok(Type::Named(name.clone()));
                 }
+                if let Some(return_type) = self.check_stdlib_named_function_call(callee, pos_args, named_args)? {
+                    return Ok(return_type);
+                }
                 // Type-check callee first
                 let callee_type = self.check_expr(callee)?;
 

--- a/core/src/typ/type_checker/expressions/calls.rs
+++ b/core/src/typ/type_checker/expressions/calls.rs
@@ -6,6 +6,27 @@ use anyhow::Result;
 impl TypeChecker {
     /// Check function call type
     pub(super) fn check_function_call(&mut self, func: &Expr, args: &[Box<Expr>]) -> Result<Type> {
+        if let Some(Type::Function {
+            params,
+            named_params,
+            return_type,
+        }) = self.stdlib_call_function_type(func)
+        {
+            if !named_params.is_empty() || params.len() != args.len() {
+                return Err(Self::type_err(
+                    &format!("Function expects {} arguments", params.len()),
+                    None,
+                    None,
+                    Some(func.clone()),
+                ));
+            }
+            for (param_type, arg) in params.iter().zip(args.iter()) {
+                let arg_type = self.check_expr(arg)?;
+                self.inference_engine.add_constraint(param_type.clone(), arg_type);
+            }
+            return Ok(*return_type);
+        }
+
         if let Expr::Access(obj_expr, field_expr) = func {
             let receiver_ty = self.check_expr(obj_expr)?;
             if let Expr::Literal(field_val) = field_expr.as_ref()

--- a/core/src/typ/type_checker/expressions/calls.rs
+++ b/core/src/typ/type_checker/expressions/calls.rs
@@ -6,25 +6,8 @@ use anyhow::Result;
 impl TypeChecker {
     /// Check function call type
     pub(super) fn check_function_call(&mut self, func: &Expr, args: &[Box<Expr>]) -> Result<Type> {
-        if let Some(Type::Function {
-            params,
-            named_params,
-            return_type,
-        }) = self.stdlib_call_function_type(func)
-        {
-            if !named_params.is_empty() || params.len() != args.len() {
-                return Err(Self::type_err(
-                    &format!("Function expects {} arguments", params.len()),
-                    None,
-                    None,
-                    Some(func.clone()),
-                ));
-            }
-            for (param_type, arg) in params.iter().zip(args.iter()) {
-                let arg_type = self.check_expr(arg)?;
-                self.inference_engine.add_constraint(param_type.clone(), arg_type);
-            }
-            return Ok(*return_type);
+        if let Some(return_type) = self.check_stdlib_function_call(func, args)? {
+            return Ok(return_type);
         }
 
         if let Expr::Access(obj_expr, field_expr) = func {

--- a/core/src/typ/type_checker/expressions/literals.rs
+++ b/core/src/typ/type_checker/expressions/literals.rs
@@ -1,0 +1,33 @@
+use crate::expr::TemplateStringPart;
+use crate::typ::type_checker::TypeChecker;
+use crate::val::{LiteralVal, Type};
+use anyhow::Result;
+
+impl TypeChecker {
+    pub(super) fn check_template_string(&mut self, parts: &[TemplateStringPart]) -> Result<Type> {
+        for part in parts {
+            if let TemplateStringPart::Expr(expr) = part {
+                let expr_type = self.check_expr(expr)?;
+                self.coerce_to_string(&expr_type);
+            }
+        }
+        Ok(Type::String)
+    }
+
+    pub(super) fn check_literal(&mut self, val: &LiteralVal) -> Result<Type> {
+        match val {
+            LiteralVal::Nil => Ok(Type::Nil),
+            LiteralVal::Bool(_) => Ok(Type::Bool),
+            LiteralVal::Int(_) => Ok(Type::Int),
+            LiteralVal::Float(_) => Ok(Type::Float),
+            LiteralVal::ShortStr(_) => Ok(Type::String),
+            value if value.as_str().is_some() => Ok(Type::String),
+            LiteralVal::String(_) => Ok(Type::String),
+        }
+    }
+
+    /// Infer type from a LiteralVal (for use in literal checking).
+    pub(in crate::typ::type_checker) fn infer_val_type(&mut self, val: &LiteralVal) -> Result<Type> {
+        self.check_literal(val)
+    }
+}

--- a/core/src/typ/type_checker/expressions/stdlib.rs
+++ b/core/src/typ/type_checker/expressions/stdlib.rs
@@ -1,0 +1,59 @@
+use crate::expr::Expr;
+use crate::typ::type_checker::TypeChecker;
+use crate::val::Type;
+
+impl TypeChecker {
+    pub(super) fn stdlib_call_function_type(&self, func: &Expr) -> Option<Type> {
+        let Expr::Access(expr, field) = func else {
+            return None;
+        };
+        self.stdlib_access_function_type(expr, field)
+    }
+
+    pub(super) fn stdlib_access_function_type(&self, expr: &Expr, field: &Expr) -> Option<Type> {
+        let Expr::Var(module) = expr else {
+            return None;
+        };
+        let field_name = match field {
+            Expr::Literal(value) => value.as_str()?,
+            Expr::Var(name) => name.as_str(),
+            _ => return None,
+        };
+        let (params, return_type) = stdlib_function_signature(module, field_name)?;
+        Some(Type::Function {
+            params,
+            named_params: Vec::new(),
+            return_type: Box::new(return_type),
+        })
+    }
+}
+
+fn stdlib_function_signature(module: &str, field: &str) -> Option<(Vec<Type>, Type)> {
+    let any = || Type::Any;
+    let unary_any = || vec![Type::Any];
+    let binary_any = || vec![Type::Any, Type::Any];
+
+    match (module, field) {
+        ("os", "arch" | "hostname" | "os") => Some((Vec::new(), Type::String)),
+        ("os", "clock") => Some((Vec::new(), Type::Float)),
+        ("os", "epoch" | "time") => Some((Vec::new(), Type::Int)),
+
+        ("env", "get") => Some((unary_any(), Type::Any)),
+        ("env", "get_or") => Some((binary_any(), Type::String)),
+        ("env", "has") => Some((unary_any(), Type::Bool)),
+
+        ("math", "abs" | "max" | "min") => Some((unary_any(), Type::Any)),
+        ("math", "clamp") => Some((vec![any(), any(), any()], Type::Int)),
+        ("math", "ceil" | "floor" | "round" | "to_int" | "trunc") => Some((unary_any(), Type::Int)),
+        (
+            "math",
+            "acos" | "asin" | "atan" | "cbrt" | "cos" | "cosh" | "exp" | "fract" | "log" | "log10" | "log2" | "sin"
+            | "sinh" | "sqrt" | "tan" | "tanh" | "to_float",
+        ) => Some((unary_any(), Type::Float)),
+        ("math", "atan2" | "hypot" | "pow") => Some((binary_any(), Type::Float)),
+        ("math", "is_inf" | "is_nan") => Some((unary_any(), Type::Bool)),
+        ("math", "random") => Some((Vec::new(), Type::Float)),
+
+        _ => None,
+    }
+}

--- a/core/src/typ/type_checker/expressions/stdlib.rs
+++ b/core/src/typ/type_checker/expressions/stdlib.rs
@@ -1,59 +1,195 @@
 use crate::expr::Expr;
 use crate::typ::type_checker::TypeChecker;
-use crate::val::Type;
+use crate::val::{FunctionNamedParamType, Type};
+use anyhow::Result;
+use std::collections::HashSet;
 
 impl TypeChecker {
-    pub(super) fn stdlib_call_function_type(&self, func: &Expr) -> Option<Type> {
-        let Expr::Access(expr, field) = func else {
-            return None;
+    pub(super) fn check_stdlib_function_call(&mut self, func: &Expr, args: &[Box<Expr>]) -> Result<Option<Type>> {
+        let Some(path) = access_segments(func) else {
+            return Ok(None);
         };
-        self.stdlib_access_function_type(expr, field)
+        let Some((module, field)) = canonical_stdlib_call_path(&path, args.len()) else {
+            return Ok(None);
+        };
+
+        if module == "math" && field == "clamp" {
+            self.check_math_clamp_args(args, &[])?;
+            return Ok(Some(Type::Int));
+        }
+
+        let Some((params, named_params, return_type)) = stdlib_function_signature(module, field) else {
+            return Ok(None);
+        };
+        if !named_params.is_empty() || params.len() != args.len() {
+            return Err(Self::type_err(
+                &format!("Function expects {} arguments", params.len()),
+                None,
+                None,
+                Some(func.clone()),
+            ));
+        }
+        for (param_type, arg) in params.iter().zip(args.iter()) {
+            let arg_type = self.check_expr(arg)?;
+            self.inference_engine.add_constraint(param_type.clone(), arg_type);
+        }
+        Ok(Some(return_type))
+    }
+
+    pub(super) fn check_stdlib_named_function_call(
+        &mut self,
+        callee: &Expr,
+        pos_args: &[Box<Expr>],
+        named_args: &[(String, Box<Expr>)],
+    ) -> Result<Option<Type>> {
+        let Some(path) = access_segments(callee) else {
+            return Ok(None);
+        };
+        let Some((module, field)) = canonical_stdlib_call_path(&path, pos_args.len()) else {
+            return Ok(None);
+        };
+
+        if module == "math" && field == "clamp" {
+            self.check_math_clamp_args(pos_args, named_args)?;
+            return Ok(Some(Type::Int));
+        }
+
+        Ok(None)
     }
 
     pub(super) fn stdlib_access_function_type(&self, expr: &Expr, field: &Expr) -> Option<Type> {
-        let Expr::Var(module) = expr else {
-            return None;
-        };
-        let field_name = match field {
-            Expr::Literal(value) => value.as_str()?,
-            Expr::Var(name) => name.as_str(),
-            _ => return None,
-        };
-        let (params, return_type) = stdlib_function_signature(module, field_name)?;
+        let mut path = access_segments(expr)?;
+        path.push(segment_name(field)?);
+        let (module, field) = canonical_stdlib_path(&path)?;
+        self.stdlib_function_type(module, field)
+    }
+
+    fn stdlib_function_type(&self, module: &str, field: &str) -> Option<Type> {
+        let (params, named_params, return_type) = stdlib_function_signature(module, field)?;
         Some(Type::Function {
             params,
-            named_params: Vec::new(),
+            named_params,
             return_type: Box::new(return_type),
         })
     }
+
+    fn check_math_clamp_args(&mut self, pos_args: &[Box<Expr>], named_args: &[(String, Box<Expr>)]) -> Result<()> {
+        if pos_args.is_empty() || pos_args.len() > 3 {
+            return Err(Self::type_err(
+                "clamp() expects 1..3 positional arguments",
+                None,
+                None,
+                None,
+            ));
+        }
+        for arg in pos_args {
+            let arg_type = self.check_expr(arg)?;
+            self.inference_engine.add_constraint(Type::Int, arg_type);
+        }
+
+        let mut seen = HashSet::with_capacity(named_args.len());
+        for (name, expr) in named_args {
+            if name != "min" && name != "max" {
+                return Err(Self::type_err(
+                    &format!("Unknown named argument: {}", name),
+                    None,
+                    None,
+                    Some(expr.as_ref().clone()),
+                ));
+            }
+            if !seen.insert(name.as_str()) {
+                return Err(Self::type_err(
+                    &format!("Duplicate named argument: {}", name),
+                    None,
+                    None,
+                    Some(expr.as_ref().clone()),
+                ));
+            }
+            let arg_type = self.check_expr(expr)?;
+            self.inference_engine.add_constraint(Type::Int, arg_type);
+        }
+        Ok(())
+    }
 }
 
-fn stdlib_function_signature(module: &str, field: &str) -> Option<(Vec<Type>, Type)> {
+fn stdlib_function_signature(module: &str, field: &str) -> Option<(Vec<Type>, Vec<FunctionNamedParamType>, Type)> {
     let any = || Type::Any;
     let unary_any = || vec![Type::Any];
     let binary_any = || vec![Type::Any, Type::Any];
+    let no_named = || Vec::new();
 
     match (module, field) {
-        ("os", "arch" | "hostname" | "os") => Some((Vec::new(), Type::String)),
-        ("os", "clock") => Some((Vec::new(), Type::Float)),
-        ("os", "epoch" | "time") => Some((Vec::new(), Type::Int)),
+        ("os", "arch" | "hostname" | "os") => Some((Vec::new(), no_named(), Type::String)),
+        ("os", "clock") => Some((Vec::new(), no_named(), Type::Float)),
+        ("os", "epoch" | "time") => Some((Vec::new(), no_named(), Type::Int)),
 
-        ("env", "get") => Some((unary_any(), Type::Any)),
-        ("env", "get_or") => Some((binary_any(), Type::String)),
-        ("env", "has") => Some((unary_any(), Type::Bool)),
+        ("env", "get") => Some((unary_any(), no_named(), Type::Any)),
+        ("env", "get_or") => Some((binary_any(), no_named(), Type::String)),
+        ("env", "has") => Some((unary_any(), no_named(), Type::Bool)),
 
-        ("math", "abs" | "max" | "min") => Some((unary_any(), Type::Any)),
-        ("math", "clamp") => Some((vec![any(), any(), any()], Type::Int)),
-        ("math", "ceil" | "floor" | "round" | "to_int" | "trunc") => Some((unary_any(), Type::Int)),
+        ("math", "abs") => Some((unary_any(), no_named(), Type::Any)),
+        ("math", "max" | "min") => Some((binary_any(), no_named(), Type::Any)),
+        ("math", "clamp") => Some((
+            vec![any()],
+            vec![
+                FunctionNamedParamType {
+                    name: "min".to_string(),
+                    ty: Type::Optional(Box::new(Type::Int)),
+                    has_default: true,
+                },
+                FunctionNamedParamType {
+                    name: "max".to_string(),
+                    ty: Type::Optional(Box::new(Type::Int)),
+                    has_default: true,
+                },
+            ],
+            Type::Int,
+        )),
+        ("math", "ceil" | "floor" | "round" | "to_int" | "trunc") => Some((unary_any(), no_named(), Type::Int)),
         (
             "math",
             "acos" | "asin" | "atan" | "cbrt" | "cos" | "cosh" | "exp" | "fract" | "log" | "log10" | "log2" | "sin"
             | "sinh" | "sqrt" | "tan" | "tanh" | "to_float",
-        ) => Some((unary_any(), Type::Float)),
-        ("math", "atan2" | "hypot" | "pow") => Some((binary_any(), Type::Float)),
-        ("math", "is_inf" | "is_nan") => Some((unary_any(), Type::Bool)),
-        ("math", "random") => Some((Vec::new(), Type::Float)),
+        ) => Some((unary_any(), no_named(), Type::Float)),
+        ("math", "atan2" | "hypot" | "pow") => Some((binary_any(), no_named(), Type::Float)),
+        ("math", "is_inf" | "is_nan") => Some((unary_any(), no_named(), Type::Bool)),
+        ("math", "random") => Some((Vec::new(), no_named(), Type::Float)),
 
+        _ => None,
+    }
+}
+
+fn canonical_stdlib_call_path<'a>(path: &'a [&'a str], positional_count: usize) -> Option<(&'a str, &'a str)> {
+    match path {
+        ["os", "env", "get"] if positional_count == 2 => Some(("env", "get_or")),
+        _ => canonical_stdlib_path(path),
+    }
+}
+
+fn canonical_stdlib_path<'a>(path: &'a [&'a str]) -> Option<(&'a str, &'a str)> {
+    match path {
+        [module, field] => Some((module, field)),
+        ["os", "env", field] => Some(("env", field)),
+        _ => None,
+    }
+}
+
+fn access_segments(expr: &Expr) -> Option<Vec<&str>> {
+    match expr {
+        Expr::Var(name) => Some(vec![name.as_str()]),
+        Expr::Access(base, field) => {
+            let mut path = access_segments(base)?;
+            path.push(segment_name(field)?);
+            Some(path)
+        }
+        _ => None,
+    }
+}
+
+fn segment_name(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::Var(name) => Some(name.as_str()),
+        Expr::Literal(value) => value.as_str(),
         _ => None,
     }
 }

--- a/core/src/typ/type_system.rs
+++ b/core/src/typ/type_system.rs
@@ -375,6 +375,11 @@ impl TypeInferenceEngine {
             // Same types unify
             (a, b) if a == b => Ok(()),
 
+            // `Any` is a weak gradual-typing constraint. It must not bind an
+            // otherwise fresh type variable, because later concrete call-site
+            // constraints should still be able to refine that variable.
+            (Type::Any, _) | (_, Type::Any) => Ok(()),
+
             // Variable unification
             (Type::Variable(var), typ) | (typ, Type::Variable(var)) => {
                 if Self::occurs_check(&var, &typ) {

--- a/core/src/typ/type_system_test.rs
+++ b/core/src/typ/type_system_test.rs
@@ -291,6 +291,23 @@ mod tests {
     }
 
     #[test]
+    fn test_type_inference_any_does_not_block_later_concrete_constraint() {
+        let registry = TypeRegistry::new();
+        let mut engine = TypeInferenceEngine::new(registry);
+        let var = engine.fresh_type_var();
+
+        engine.add_constraint(var.clone(), Type::Any);
+        engine.add_constraint(var.clone(), Type::String);
+
+        let substitutions = engine.solve_constraints().unwrap();
+        if let Type::Variable(name) = var {
+            assert_eq!(substitutions.get(&name), Some(&Type::String));
+        } else {
+            panic!("expected type variable");
+        }
+    }
+
+    #[test]
     fn test_type_substitution() {
         let mut substitutions = HashMap::new();
         substitutions.insert("T".to_string(), Type::Int);

--- a/core/src/typ/type_system_test.rs
+++ b/core/src/typ/type_system_test.rs
@@ -297,8 +297,14 @@ mod tests {
         let var = engine.fresh_type_var();
 
         engine.add_constraint(var.clone(), Type::Any);
-        engine.add_constraint(var.clone(), Type::String);
+        let substitutions = engine.solve_constraints().unwrap();
+        if let Type::Variable(name) = &var {
+            assert_eq!(substitutions.get(name), None);
+        } else {
+            panic!("expected type variable");
+        }
 
+        engine.add_constraint(var.clone(), Type::String);
         let substitutions = engine.solve_constraints().unwrap();
         if let Type::Variable(name) = var {
             assert_eq!(substitutions.get(&name), Some(&Type::String));

--- a/lsp/README.md
+++ b/lsp/README.md
@@ -86,6 +86,10 @@ Notes:
 - The file path must be relative (no absolute paths or `..`).
 - Output is prettified JSON suitable for piping to `jq`.
 
+### Type Diagnostics
+
+The analyzer runs strict type checking after parsing a full statement program. Unannotated function parameters are checked after the whole program has contributed call-site constraints, so a parameter such as `fn should_run(name)` is accepted when later calls consistently pass `String` values. If no concrete call-site or body constraint resolves the parameter, the diagnostic is reported on the parameter name instead of at the top of the file.
+
 ### Integration with Editors
 
 #### VS Code
@@ -100,7 +104,7 @@ Create a VS Code extension that launches the LSP server:
       "extensions": [".lk"]
     }]
   },
-  "activationEvents": ["onLanguage:lk"]
+  "activationEvents": ["onLanguage:lk", "workspaceContains:Lk.toml"]
 }
 ```
 

--- a/lsp/src/analyzer/analysis_impl.rs
+++ b/lsp/src/analyzer/analysis_impl.rs
@@ -1077,12 +1077,15 @@ impl LkAnalyzer {
             Ok(_) => Vec::new(),
             Err(err) => {
                 let range = Self::type_error_range(&err, tokens, spans, content);
+                let message = Self::type_error_from_anyhow(&err)
+                    .map(|type_error| type_error.message.clone())
+                    .unwrap_or_else(|| err.to_string());
                 let mut diagnostic = Diagnostic::new(
                     range,
                     Some(DiagnosticSeverity::ERROR),
                     None,
                     Some("lk".to_string()),
-                    err.to_string(),
+                    message,
                     None,
                     None,
                 );
@@ -1104,21 +1107,34 @@ impl LkAnalyzer {
                     return range;
                 }
             }
+            if let Some(range) = Self::implicit_any_error_range(Some(type_error), &type_error.message, tokens, spans) {
+                return range;
+            }
         }
         let message = err.to_string();
-        if let Some(range) = Self::implicit_any_error_range(&message, tokens, spans) {
+        if let Some(range) = Self::implicit_any_error_range(None, &message, tokens, spans) {
             return range;
         }
         Self::default_error_range(content)
     }
 
-    pub(crate) fn implicit_any_error_range(message: &str, tokens: &[token::Token], spans: &[Span]) -> Option<Range> {
-        let fn_name = Self::quoted_after(message, "Function '")?;
+    pub(crate) fn implicit_any_error_range(
+        type_error: Option<&typ::TypeError>,
+        message: &str,
+        tokens: &[token::Token],
+        spans: &[Span],
+    ) -> Option<Range> {
+        let fn_name = type_error
+            .and_then(|err| err.function_name.as_deref())
+            .or_else(|| Self::quoted_after(message, "Function '"))?;
         let function = Self::scan_function_blocks(tokens, spans)
             .into_iter()
             .find(|block| block.name == fn_name)?;
 
-        if let Some(param_name) = Self::quoted_after(message, "parameter '") {
+        if let Some(param_name) = type_error
+            .and_then(|err| err.parameter_name.as_deref())
+            .or_else(|| Self::quoted_after(message, "parameter '"))
+        {
             if let Some((_, span)) = function.param_spans.iter().find(|(name, _)| name == param_name) {
                 return Some(Self::span_to_range(span));
             }

--- a/lsp/src/analyzer/analysis_impl.rs
+++ b/lsp/src/analyzer/analysis_impl.rs
@@ -1105,7 +1105,33 @@ impl LkAnalyzer {
                 }
             }
         }
+        let message = err.to_string();
+        if let Some(range) = Self::implicit_any_error_range(&message, tokens, spans) {
+            return range;
+        }
         Self::default_error_range(content)
+    }
+
+    pub(crate) fn implicit_any_error_range(message: &str, tokens: &[token::Token], spans: &[Span]) -> Option<Range> {
+        let fn_name = Self::quoted_after(message, "Function '")?;
+        let function = Self::scan_function_blocks(tokens, spans)
+            .into_iter()
+            .find(|block| block.name == fn_name)?;
+
+        if let Some(param_name) = Self::quoted_after(message, "parameter '") {
+            if let Some((_, span)) = function.param_spans.iter().find(|(name, _)| name == param_name) {
+                return Some(Self::span_to_range(span));
+            }
+        }
+
+        Some(Self::span_to_range(&function.name_span))
+    }
+
+    fn quoted_after<'a>(message: &'a str, marker: &str) -> Option<&'a str> {
+        let start = message.find(marker)? + marker.len();
+        let rest = &message[start..];
+        let end = rest.find('\'')?;
+        Some(&rest[..end])
     }
 
     pub(crate) fn type_error_from_anyhow(err: &anyhow::Error) -> Option<&typ::TypeError> {

--- a/lsp/src/analyzer/tests.rs
+++ b/lsp/src/analyzer/tests.rs
@@ -66,12 +66,12 @@ fn test_analyze_statement_program() {
     "#;
     let result = analyzer.analyze(code);
 
-    // Type checking should surface strict Any diagnostics for missing annotations
-    assert_eq!(result.diagnostics.len(), 1);
-    let diag = &result.diagnostics[0];
-    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
-    assert!(diag.message.contains("Function 'calculate_score' infers implicit Any"));
-    assert_eq!(diag.code, Some(NumberOrString::String("lk_type_error".to_string())));
+    // The later call constrains `base` to Int, so strict Any should not report a false positive.
+    assert!(
+        result.diagnostics.is_empty(),
+        "unexpected diagnostics: {:?}",
+        result.diagnostics
+    );
 
     // Should have grouped use/variable symbols and function symbols.
     assert!(result.symbols.len() >= 3);
@@ -392,6 +392,47 @@ fn test_type_inlay_hints_let_and_define() {
     hints.extend(analyzer.compute_define_type_hints(src, full_range(src)));
     assert!(!hints.is_empty(), "expected type hints for let/define, got none");
     assert!(hints.iter().all(|h| h.kind == Some(InlayHintKind::TYPE)));
+}
+
+#[test]
+fn test_business_workload_should_run_infers_from_string_calls() {
+    let mut analyzer = create_analyzer();
+    let code = include_str!("../../../bench/workloads_business_algorithms.lk");
+    let result = analyzer.analyze(code);
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.message.contains("Function 'should_run' infers implicit Any")),
+        "should_run(name) should infer name from later string call sites"
+    );
+}
+
+#[test]
+fn test_unconstrained_implicit_any_diagnostic_points_to_parameter() {
+    let mut analyzer = create_analyzer();
+    let code = r#"
+        let workload_filter = os.env.get("LK_WORKLOAD_FILTER", "");
+        fn should_run(name) {
+            return workload_filter == "" || workload_filter == name;
+        }
+    "#;
+    let result = analyzer.analyze(code);
+
+    assert_eq!(result.diagnostics.len(), 1);
+    let diag = &result.diagnostics[0];
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(diag.code, Some(NumberOrString::String("lk_type_error".to_string())));
+    assert_eq!(
+        diag.message,
+        "Function 'should_run' infers implicit Any for parameter 'name'; add explicit annotations"
+    );
+    assert_eq!(
+        diag.range,
+        Range::new(Position::new(2, 22), Position::new(2, 26)),
+        "implicit Any diagnostic should point at the unannotated parameter"
+    );
 }
 
 fn full_range(s: &str) -> Range {

--- a/lsp/src/analyzer/tests.rs
+++ b/lsp/src/analyzer/tests.rs
@@ -413,9 +413,8 @@ fn test_business_workload_should_run_infers_from_string_calls() {
 fn test_unconstrained_implicit_any_diagnostic_points_to_parameter() {
     let mut analyzer = create_analyzer();
     let code = r#"
-        let workload_filter = os.env.get("LK_WORKLOAD_FILTER", "");
         fn should_run(name) {
-            return workload_filter == "" || workload_filter == name;
+            return true;
         }
     "#;
     let result = analyzer.analyze(code);
@@ -430,7 +429,7 @@ fn test_unconstrained_implicit_any_diagnostic_points_to_parameter() {
     );
     assert_eq!(
         diag.range,
-        Range::new(Position::new(2, 22), Position::new(2, 26)),
+        Range::new(Position::new(1, 22), Position::new(1, 26)),
         "implicit Any diagnostic should point at the unannotated parameter"
     );
 }

--- a/lsp/src/server/handlers.rs
+++ b/lsp/src/server/handlers.rs
@@ -29,6 +29,79 @@ mod initialization;
 
 use initialization::semantic_tokens_provider_from;
 
+fn server_capabilities_from(params: &InitializeParams) -> ServerCapabilities {
+    ServerCapabilities {
+        // Switch to INCREMENTAL now that we apply ranges with UTF-16 mapping.
+        // Save notifications let us refresh the workspace cache after edits.
+        text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
+            open_close: Some(true),
+            change: Some(TextDocumentSyncKind::INCREMENTAL),
+            will_save: Some(false),
+            will_save_wait_until: Some(false),
+            save: Some(TextDocumentSyncSaveOptions::Supported(true)),
+        })),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        completion_provider: Some(CompletionOptions {
+            resolve_provider: Some(false),
+            trigger_characters: Some(vec![
+                ".".to_string(),
+                "\"".to_string(),
+                "{".to_string(),
+                ",".to_string(),
+                ":".to_string(),
+            ]),
+            work_done_progress_options: Default::default(),
+            all_commit_characters: None,
+            completion_item: None,
+        }),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
+            retrigger_characters: None,
+            work_done_progress_options: Default::default(),
+        }),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        references_provider: Some(OneOf::Left(true)),
+        definition_provider: Some(OneOf::Left(true)),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Left(true)),
+        // Diagnostics are pushed via textDocument/publishDiagnostics. Advertising
+        // pull diagnostics as well makes VS Code show the same diagnostic twice.
+        diagnostic_provider: None,
+        semantic_tokens_provider: semantic_tokens_provider_from(params),
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+        code_lens_provider: Some(CodeLensOptions {
+            resolve_provider: Some(false),
+        }),
+        document_formatting_provider: Some(OneOf::Left(true)),
+        inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(InlayHintOptions {
+            work_done_progress_options: Default::default(),
+            resolve_provider: Some(false),
+        }))),
+        // Workspace capabilities left default; client will still send configuration changes
+        ..Default::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_capabilities_use_push_diagnostics_only() {
+        let params = InitializeParams::default();
+        let capabilities = server_capabilities_from(&params);
+
+        assert!(
+            capabilities.diagnostic_provider.is_none(),
+            "LK pushes diagnostics with textDocument/publishDiagnostics; pull diagnostics duplicate VS Code output"
+        );
+        assert!(
+            capabilities.inlay_hint_provider.is_some(),
+            "removing pull diagnostics must not disable inlay hints"
+        );
+    }
+}
+
 #[tower_lsp::async_trait]
 impl LanguageServer for LkLanguageServer {
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
@@ -50,59 +123,7 @@ impl LanguageServer for LkLanguageServer {
         self.workspace_cache.set_root(workspace_root);
 
         Ok(InitializeResult {
-            capabilities: ServerCapabilities {
-                // Switch to INCREMENTAL now that we apply ranges with UTF-16 mapping.
-                // Save notifications let us refresh the workspace cache after edits.
-                text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
-                    open_close: Some(true),
-                    change: Some(TextDocumentSyncKind::INCREMENTAL),
-                    will_save: Some(false),
-                    will_save_wait_until: Some(false),
-                    save: Some(TextDocumentSyncSaveOptions::Supported(true)),
-                })),
-                hover_provider: Some(HoverProviderCapability::Simple(true)),
-                completion_provider: Some(CompletionOptions {
-                    resolve_provider: Some(false),
-                    trigger_characters: Some(vec![
-                        ".".to_string(),
-                        "\"".to_string(),
-                        "{".to_string(),
-                        ",".to_string(),
-                        ":".to_string(),
-                    ]),
-                    work_done_progress_options: Default::default(),
-                    all_commit_characters: None,
-                    completion_item: None,
-                }),
-                signature_help_provider: Some(SignatureHelpOptions {
-                    trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
-                    retrigger_characters: None,
-                    work_done_progress_options: Default::default(),
-                }),
-                document_symbol_provider: Some(OneOf::Left(true)),
-                references_provider: Some(OneOf::Left(true)),
-                definition_provider: Some(OneOf::Left(true)),
-                document_highlight_provider: Some(OneOf::Left(true)),
-                rename_provider: Some(OneOf::Left(true)),
-                diagnostic_provider: Some(DiagnosticServerCapabilities::Options(DiagnosticOptions {
-                    identifier: Some("lk".to_string()),
-                    inter_file_dependencies: false,
-                    workspace_diagnostics: false,
-                    work_done_progress_options: Default::default(),
-                })),
-                semantic_tokens_provider: semantic_tokens_provider_from(&params),
-                code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-                code_lens_provider: Some(CodeLensOptions {
-                    resolve_provider: Some(false),
-                }),
-                document_formatting_provider: Some(OneOf::Left(true)),
-                inlay_hint_provider: Some(OneOf::Right(InlayHintServerCapabilities::Options(InlayHintOptions {
-                    work_done_progress_options: Default::default(),
-                    resolve_provider: Some(false),
-                }))),
-                // Workspace capabilities left default; client will still send configuration changes
-                ..Default::default()
-            },
+            capabilities: server_capabilities_from(&params),
             server_info: Some(ServerInfo {
                 name: "LK Language Server".to_string(),
                 version: Some("0.1.0".to_string()),

--- a/vsc-ext/.vscode/settings.json
+++ b/vsc-ext/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "lkr.lsp.semanticTokens.enabled": true,
-    "lkr.lsp.semanticTokens.throttleMs": 150,
+    "lk.lsp.semanticTokens.enabled": true,
+    "lk.lsp.semanticTokens.throttleMs": 150,
 }

--- a/vsc-ext/lsp/README.md
+++ b/vsc-ext/lsp/README.md
@@ -51,6 +51,11 @@ The previous standalone `lk-highlight` extension has been merged into this packa
   - Document symbols
 - Inlay hints (parameter + type hints)
 
+### Type diagnostics
+
+- Strict type diagnostics use whole-program call-site constraints before reporting implicit `Any` parameters.
+- If a function parameter remains unresolved, the error is attached to the parameter name rather than the file header.
+
 ### Stdlib awareness
 - The client queries the Rust LK language server for stdlib modules and exports. Module-aware completions support:
   - `use <module>` / `from <module>` name completion
@@ -68,7 +73,6 @@ The previous standalone `lk-highlight` extension has been merged into this packa
   - `lk.lsp.inlayHints.enabled`
   - `lk.lsp.inlayHints.parameters.enabled`
   - `lk.lsp.inlayHints.types.enabled`
-  - `lk.lsp.inlayHints.throttleMs`
 
 ## Requirements
 

--- a/vsc-ext/lsp/package-lock.json
+++ b/vsc-ext/lsp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
+        "minimatch": "^5.1.9",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -788,6 +789,30 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -967,14 +992,12 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "dev": true,
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -2539,16 +2562,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10"
       }
     },
     "node_modules/minimist": {
@@ -3900,27 +3922,6 @@
       },
       "engines": {
         "vscode": "^1.82.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver-protocol": {

--- a/vsc-ext/lsp/package.json
+++ b/vsc-ext/lsp/package.json
@@ -22,7 +22,8 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "onLanguage:lk"
+    "onLanguage:lk",
+    "workspaceContains:Lk.toml"
   ],
   "contributes": {
     "languages": [
@@ -194,12 +195,6 @@
           "default": true,
           "description": "Enable inlay hints (inline editor hints) from LK LSP"
         },
-        "lk.lsp.inlayHints.throttleMs": {
-          "type": "number",
-          "default": 50,
-          "minimum": 0,
-          "description": "Throttle consecutive inlay hint requests per document (ms). Set 0 to disable."
-        },
         "lk.lsp.inlayHints.parameters.enabled": {
           "type": "boolean",
           "default": true,
@@ -274,6 +269,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
+    "minimatch": "^5.1.9",
     "vscode-languageclient": "^9.0.1"
   }
 }

--- a/vsc-ext/lsp/src/extension.ts
+++ b/vsc-ext/lsp/src/extension.ts
@@ -108,7 +108,6 @@ const runtime = {
   semanticTokensMode: 'auto' as 'auto' | 'rangeOnly' | 'fullOnly',
   autoRangeAtLines: 800,
   inlayHintsEnabled: true,
-  inlayHintsThrottleMs: 50,
   inlayHintsShowParameters: true,
   inlayHintsShowTypes: true,
   checkingDelayMs: 120,
@@ -311,7 +310,6 @@ export function activate(context: vscode.ExtensionContext) {
   runtime.semanticTokensMode = (config.get<string>('semanticTokens.mode', 'auto') as any) || 'auto';
   runtime.autoRangeAtLines = Math.max(1, Number(config.get<number>('semanticTokens.autoRangeAtLines', 800)) || 800);
   runtime.inlayHintsEnabled = config.get<boolean>('inlayHints.enabled', true);
-  runtime.inlayHintsThrottleMs = Math.max(0, Number(config.get<number>('inlayHints.throttleMs', 50)) || 0);
   runtime.inlayHintsShowParameters = config.get<boolean>('inlayHints.parameters.enabled', true);
   runtime.inlayHintsShowTypes = config.get<boolean>('inlayHints.types.enabled', true);
   runtime.checkingDelayMs = Math.max(0, Number(config.get<number>('ui.checkingDelayMs', 120)) || 120);
@@ -350,10 +348,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Lightweight, per-document throttle map (separate for tokens and hints)
   const lastTokenReqAt = new Map<string, number>();
-  const lastInlayReqAt = new Map<string, number>();
   // Simple per-document concurrency gates to avoid piling up work while scrolling
   const tokenInFlight = new Set<string>();
-  const inlayInFlight = new Set<string>();
   // Keyed in-flight promises to dedupe identical requests
   const dedupeTokenRange = new Map<string, Promise<any>>();
   const dedupeInlay = new Map<string, Promise<any>>();
@@ -487,7 +483,7 @@ export function activate(context: vscode.ExtensionContext) {
       dedupeTokenRange.set(cacheKey, wrapped);
       return wrapped as any;
     },
-    // Inlay hints: show checking spinner and support throttling + filtering
+    // Inlay hints: show checking spinner, dedupe identical requests, and filter by settings.
     provideInlayHints(document, range, token, next) {
       if (!runtime.inlayHintsEnabled) {
         return null;
@@ -495,34 +491,19 @@ export function activate(context: vscode.ExtensionContext) {
       if (token?.isCancellationRequested) return null;
       const reqVersion = document.version;
       const key = document.uri.toString();
-      if (inlayInFlight.has(key)) {
-        perfLog('skip.inlayHints.inflight', 0);
-        return null;
-      }
-      beginChecking('inlayHints');
-      if (runtime.inlayHintsThrottleMs > 0) {
-        const now = Date.now();
-        const last = lastInlayReqAt.get(key) || 0;
-        if (now - last < runtime.inlayHintsThrottleMs) {
-          endChecking();
-          return null;
-        }
-        lastInlayReqAt.set(key, now);
-      }
       const rKey = `${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`;
       const settingsKey = `${Number(runtime.inlayHintsShowParameters)}:${Number(runtime.inlayHintsShowTypes)}`;
       const cacheKey = `${key}#v${reqVersion}#I#${rKey}#${settingsKey}`;
       if (enableCaching) {
         const cached = inlayCache.get(cacheKey);
         if (cached !== undefined) {
-          endChecking();
           return cached as any;
         }
       }
       if (dedupeInlay.has(cacheKey)) {
         return dedupeInlay.get(cacheKey)! as any;
       }
-      inlayInFlight.add(key);
+      beginChecking('inlayHints');
       const res = withTiming('middleware.inlayHints', () => next(document, range, token));
       const filter = (hints: vscode.InlayHint[] | null | undefined) => {
         if (!hints) return hints;
@@ -544,7 +525,7 @@ export function activate(context: vscode.ExtensionContext) {
             if (enableCaching) inlayCache.set(cacheKey, filtered as any);
             return filtered;
           })
-          .finally(() => { inlayInFlight.delete(key); dedupeInlay.delete(cacheKey); endChecking(); });
+          .finally(() => { dedupeInlay.delete(cacheKey); endChecking(); });
         dedupeInlay.set(cacheKey, p as any);
         return p as any;
       } else {
@@ -553,7 +534,6 @@ export function activate(context: vscode.ExtensionContext) {
           if (enableCaching) inlayCache.set(cacheKey, filtered as any);
           return filtered;
         } finally {
-          inlayInFlight.delete(key);
           endChecking();
         }
       }
@@ -584,7 +564,6 @@ export function activate(context: vscode.ExtensionContext) {
     runtime.semanticTokensMode = (cfg.get<string>('semanticTokens.mode', 'auto') as any) || 'auto';
     runtime.autoRangeAtLines = Math.max(1, Number(cfg.get<number>('semanticTokens.autoRangeAtLines', 800)) || 800);
     runtime.inlayHintsEnabled = cfg.get<boolean>('inlayHints.enabled', true);
-    runtime.inlayHintsThrottleMs = Math.max(0, Number(cfg.get<number>('inlayHints.throttleMs', 50)) || 0);
     runtime.inlayHintsShowParameters = cfg.get<boolean>('inlayHints.parameters.enabled', true);
     runtime.inlayHintsShowTypes = cfg.get<boolean>('inlayHints.types.enabled', true);
     // Perf tracing settings


### PR DESCRIPTION
## Summary
- keep LK LSP active/status behavior and reduce duplicated diagnostics/inlay flicker
- defer strict implicit Any checks until whole-program call-site constraints are solved
- add stdlib call return types for LSP type diagnostics, including os/math/env helpers
- document strict type diagnostic behavior and add regression coverage for should_run(name)

## Verification
- cargo test -p lk-core
- cargo test -p lk-lsp
- npm --prefix vsc-ext/lsp run compile
- npm --prefix vsc-ext/lsp run package
- target/debug/lk-lsp --analyze bench/workloads_business_algorithms.lk | jq '.diagnostics' => []

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 函数参数可基于后续调用推断类型，减少显式注解需求。
  * 新增对标准库函数的类型信息以提升类型检查准确性。
  * 编辑器扩展新增基于工作区内容的激活触发器。

* **Improvements**
  * 严格类型检查改为延迟验证以收集更多上下文再报告错误。
  * 类型推断改进，避免未解析的 Any 阻塞后续具体约束。
  * 诊断定位更精确，错误可指向具体参数位置。

* **Documentation**
  * 增补“类型诊断”文档，说明诊断触发与定位规则。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->