### PR TITLE
fix: correctness 夜跑三回归清零(A0-A3)—— host_roots 机制 + JmpBuf 复用 + fuzz 预热

### DIFF
--- a/.github/workflows/correctness.yml
+++ b/.github/workflows/correctness.yml
@@ -35,6 +35,15 @@ jobs:
         with:
           toolchain-file: rust-toolchain.toml
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Keep partial build progress from red runs: a regression that keeps
+          # the job failing must not also keep every following run on a cold
+          # cache (the fresh-seed fuzz timed out for days on exactly this).
+          cache-on-failure: true
+      # `lk compile` builds this on demand inside a test's per-case timeout —
+      # prebuild it so timeouts measure the compile itself, not a cold cargo.
+      - name: prebuild the lk-api staticlib
+        run: cargo build -p lk-api --features ffi --release
       - name: cargo test under LK_GC_STRESS
         run: LK_GC_STRESS=1 cargo test -p lk-core -p lk-stdlib -p lk-cli
 
@@ -49,6 +58,10 @@ jobs:
         with:
           toolchain-file: rust-toolchain.toml
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: prebuild the lk-api staticlib
+        run: cargo build -p lk-api --features ffi --release
       - name: hand-written differential cases
         run: LK_NATIVE_SANITIZE=address,undefined cargo test -p lk-cli --test aot_differential_test
       - name: examples corpus differential
@@ -74,6 +87,10 @@ jobs:
       - name: install nightly (sanitizer build)
         run: rustup toolchain install nightly --profile minimal
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: prebuild the lk-api staticlib
+        run: cargo build -p lk-api --features ffi --release
       - name: build ASan lkrt
         run: bash scripts/build_lkrt_asan.sh
       - name: differential suites against the instrumented lkrt
@@ -92,6 +109,10 @@ jobs:
         with:
           toolchain-file: rust-toolchain.toml
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: prebuild the lk-api staticlib
+        run: cargo build -p lk-api --features ffi --release
       - name: fuzz with the run id as seed (printed for reproduction)
         run: LK_FUZZ_SEED=${{ github.run_id }} LK_FUZZ_CASES=500 cargo test -p lk-cli --test aot_fuzz_differential_test -- --nocapture
       - name: artifact decoder/verifier fuzz with the run id as seed

--- a/cli/tests/aot_differential_test.rs
+++ b/cli/tests/aot_differential_test.rs
@@ -91,13 +91,20 @@ fn run_differential(area: &str, cases: &[Case]) {
             case.name,
             String::from_utf8_lossy(&exe.stderr)
         );
+        // Leak detection stays off for sanitized native runs: a raise
+        // longjmps over Rust frames whose plain temporaries (Vecs, boxes)
+        // then never drop — leaked *by design* (lkrt's arena model), and
+        // LSan's exit-time report both fails the run and swallows buffered
+        // stdout. ASan's use-after-free/overflow checks remain fully on.
         let native = Command::new(dir.join(case.name))
+            .env("ASAN_OPTIONS", "detect_leaks=0")
             .output()
             .expect("spawn compiled executable");
         let native_stdout = String::from_utf8_lossy(&native.stdout).into_owned();
 
         assert_eq!(
-            vm_stdout, native_stdout,
+            vm_stdout,
+            native_stdout,
             "[{area}/{}] stdout diverged (vm vs native): vm={:?} native={:?} stderr(vm)={} stderr(native)={}",
             case.name,
             vm.status,

--- a/cli/tests/aot_differential_test.rs
+++ b/cli/tests/aot_differential_test.rs
@@ -98,8 +98,12 @@ fn run_differential(area: &str, cases: &[Case]) {
 
         assert_eq!(
             vm_stdout, native_stdout,
-            "[{area}/{}] stdout diverged (vm vs native)",
-            case.name
+            "[{area}/{}] stdout diverged (vm vs native): vm={:?} native={:?} stderr(vm)={} stderr(native)={}",
+            case.name,
+            vm.status,
+            native.status,
+            String::from_utf8_lossy(&vm.stderr),
+            String::from_utf8_lossy(&native.stderr)
         );
         assert_eq!(
             vm.status.success(),

--- a/cli/tests/aot_fuzz_differential_test.rs
+++ b/cli/tests/aot_fuzz_differential_test.rs
@@ -890,14 +890,19 @@ fn run_case(dir: &std::path::Path, name: &str, source: &str, seed: u64) -> CaseO
     assert_eq!(
         vm_stdout,
         native_stdout,
-        "{}",
-        context("stdout diverged between VM and native")
+        "{}\nvm status: {:?}\nnative status: {:?}\nvm stderr: {vm_stderr}\nnative stderr: {}",
+        context("stdout diverged between VM and native"),
+        vm.status,
+        native.status,
+        String::from_utf8_lossy(&native.stderr)
     );
     assert_eq!(
         vm.status.success(),
         native.status.success(),
-        "{}\nnative stderr: {}",
+        "{}\nvm status: {:?}\nnative status: {:?}\nvm stderr: {vm_stderr}\nnative stderr: {}",
         context("success/failure diverged between VM and native"),
+        vm.status,
+        native.status,
         String::from_utf8_lossy(&native.stderr)
     );
     CaseOutcome { compared: true }

--- a/cli/tests/aot_fuzz_differential_test.rs
+++ b/cli/tests/aot_fuzz_differential_test.rs
@@ -898,6 +898,24 @@ fn run_case(dir: &std::path::Path, name: &str, source: &str, seed: u64) -> CaseO
     CaseOutcome { compared: true }
 }
 
+/// `lk compile` builds the lk-api staticlib on demand *inside the compile
+/// child* (`ensure_lk_api_staticlib`, cli/src/main.rs) whenever a case needs
+/// the Tier 0 bundle or the Tier 1 hybrid link. On a cold cache that is a
+/// full release build — minutes, not seconds — and it lands inside a single
+/// case's 60s compile timeout (the nightly fresh-seed job died on exactly
+/// this: the first bridge-needing case's number drifts with the seed). Warm
+/// the build once, untimed, so the per-case timeout measures the compile
+/// itself. Must mirror the cargo invocation in `ensure_lk_api_staticlib`.
+fn warm_lk_api_staticlib() {
+    let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("..");
+    let status = Command::new("cargo")
+        .current_dir(&workspace)
+        .args(["build", "-p", "lk-api", "--features", "ffi", "--release"])
+        .status()
+        .expect("spawn cargo build lk-api");
+    assert!(status.success(), "failed to prebuild the lk-api staticlib");
+}
+
 #[test]
 fn fuzz_differential_vm_vs_native() {
     let cases: u64 = std::env::var("LK_FUZZ_CASES")
@@ -908,6 +926,7 @@ fn fuzz_differential_vm_vs_native() {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(0xC0FF_EE00);
+    warm_lk_api_staticlib();
 
     let dir = std::env::temp_dir().join(format!("lk_aot_fuzz_{}", std::process::id()));
     let _ = fs::remove_dir_all(&dir);

--- a/cli/tests/aot_fuzz_differential_test.rs
+++ b/cli/tests/aot_fuzz_differential_test.rs
@@ -878,7 +878,12 @@ fn run_case(dir: &std::path::Path, name: &str, source: &str, seed: u64) -> CaseO
         return CaseOutcome { compared: false };
     }
 
-    let native = output_with_timeout(Command::new(dir.join(name)), "native run", &context("native run"));
+    // detect_leaks=0: raises longjmp over Rust frames whose temporaries leak
+    // by design (lkrt arena model) — LSan would fail the run and swallow
+    // buffered stdout. ASan memory-error checks stay on.
+    let mut native_cmd = Command::new(dir.join(name));
+    native_cmd.env("ASAN_OPTIONS", "detect_leaks=0");
+    let native = output_with_timeout(native_cmd, "native run", &context("native run"));
 
     let vm_stdout = String::from_utf8_lossy(&vm.stdout);
     let native_stdout = String::from_utf8_lossy(&native.stdout);

--- a/cli/tests/examples_differential_test.rs
+++ b/cli/tests/examples_differential_test.rs
@@ -23,8 +23,22 @@ fn examples_root() -> PathBuf {
 
 struct RunResult {
     stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
     success: bool,
     timed_out: bool,
+}
+
+impl RunResult {
+    /// Diagnostic block for divergence reports: exit code plus the captured
+    /// stderr (the CI log otherwise hides why a side failed).
+    fn diagnostics(&self, side: &str) -> String {
+        let code = match self.exit_code {
+            Some(code) => code.to_string(),
+            None => "killed".to_string(),
+        };
+        format!("--- {side} exit={code} stderr ---\n{}", self.stderr)
+    }
 }
 
 /// Runs a command with stdout/stderr captured to files (avoids pipe-buffer
@@ -54,6 +68,8 @@ fn run_with_timeout(mut command: Command, scratch: &Path, tag: &str) -> RunResul
     };
     RunResult {
         stdout: fs::read_to_string(&stdout_path).unwrap_or_default(),
+        stderr: fs::read_to_string(&stderr_path).unwrap_or_default(),
+        exit_code: status.and_then(|status| status.code()),
         success: status.is_some_and(|status| status.success()),
         timed_out: status.is_none(),
     }
@@ -165,13 +181,19 @@ fn examples_corpus_differential() {
 
         if vm.stdout != native.stdout {
             divergences.push(format!(
-                "[{label}] stdout diverged\n--- vm ---\n{}\n--- native ---\n{}",
-                vm.stdout, native.stdout
+                "[{label}] stdout diverged\n--- vm ---\n{}\n--- native ---\n{}\n{}\n{}",
+                vm.stdout,
+                native.stdout,
+                vm.diagnostics("vm"),
+                native.diagnostics("native")
             ));
         } else if vm.success != native.success {
             divergences.push(format!(
-                "[{label}] success/failure diverged: vm={} native={}",
-                vm.success, native.success
+                "[{label}] success/failure diverged: vm={} native={}\n{}\n{}",
+                vm.success,
+                native.success,
+                vm.diagnostics("vm"),
+                native.diagnostics("native")
             ));
         } else {
             compared.push(label);

--- a/cli/tests/examples_differential_test.rs
+++ b/cli/tests/examples_differential_test.rs
@@ -173,7 +173,12 @@ fn examples_corpus_differential() {
             ));
             continue;
         }
-        let native = run_with_timeout(Command::new(dir.join(&stem)), &scratch, &format!("{stem}_native"));
+        // detect_leaks=0: raises longjmp over Rust frames whose temporaries
+        // leak by design (lkrt arena model) — LSan would fail the run and
+        // swallow buffered stdout. ASan memory-error checks stay on.
+        let mut native_cmd = Command::new(dir.join(&stem));
+        native_cmd.env("ASAN_OPTIONS", "detect_leaks=0");
+        let native = run_with_timeout(native_cmd, &scratch, &format!("{stem}_native"));
         if native.timed_out {
             divergences.push(format!("[{label}] native run timed out while the VM completed"));
             continue;

--- a/cli/tests/examples_differential_test.rs
+++ b/cli/tests/examples_differential_test.rs
@@ -31,11 +31,14 @@ struct RunResult {
 
 impl RunResult {
     /// Diagnostic block for divergence reports: exit code plus the captured
-    /// stderr (the CI log otherwise hides why a side failed).
+    /// stderr (the CI log otherwise hides why a side failed). A missing exit
+    /// code means either the harness timeout killed the child or it died to
+    /// a signal (e.g. SIGABRT) — two very different failures, kept distinct.
     fn diagnostics(&self, side: &str) -> String {
-        let code = match self.exit_code {
-            Some(code) => code.to_string(),
-            None => "killed".to_string(),
+        let code = match (self.exit_code, self.timed_out) {
+            (Some(code), _) => code.to_string(),
+            (None, true) => "killed (harness timeout)".to_string(),
+            (None, false) => "terminated by signal".to_string(),
         };
         format!("--- {side} exit={code} stderr ---\n{}", self.stderr)
     }

--- a/core/src/vm/context/core_methods.rs
+++ b/core/src/vm/context/core_methods.rs
@@ -1307,10 +1307,14 @@ fn list_reduce(
     let acc_fn = args[1];
     let mut acc = args[0];
     for item in items {
-        // Pin the running accumulator: it lives only in this Rust frame
-        // between callbacks (the caller restores the mark).
+        // Pin the running accumulator only for the callback that consumes it
+        // (per-iteration mark/truncate keeps `host_roots` O(1) instead of
+        // growing by one entry per element).
+        let iteration_mark = state.host_roots_mark();
         state.host_root_push(acc);
-        acc = crate::vm::call_runtime_value_runtime(acc_fn, &[acc, *item], state, module, ctx.as_deref_mut())?;
+        let result = crate::vm::call_runtime_value_runtime(acc_fn, &[acc, *item], state, module, ctx.as_deref_mut());
+        state.host_roots_truncate(iteration_mark);
+        acc = result?;
     }
     Ok(Some(acc))
 }

--- a/core/src/vm/context/core_methods.rs
+++ b/core/src/vm/context/core_methods.rs
@@ -241,13 +241,20 @@ fn call_method_positional_runtime(
                 },
             };
             if let Some((state, mut ctx, module)) = runtime.parts_mut() {
+                // `items` may hold heap objects materialized off the receiver
+                // (e.g. long strings) that nothing else references — pin them
+                // for the duration of the callback loop or a GC inside the
+                // callback frees them mid-iteration.
+                let mark = state.host_roots_mark();
+                state.host_roots_extend(items.iter());
                 let result = match method_str {
-                    "filter" => list_filter(&items, &pos_args, state, module, &mut ctx)?,
-                    "map" => list_map(&items, &pos_args, state, module, &mut ctx)?,
-                    "reduce" => list_reduce(&items, &pos_args, state, module, &mut ctx)?,
-                    _ => None,
+                    "filter" => list_filter(&items, &pos_args, state, module, &mut ctx),
+                    "map" => list_map(&items, &pos_args, state, module, &mut ctx),
+                    "reduce" => list_reduce(&items, &pos_args, state, module, &mut ctx),
+                    _ => Ok(None),
                 };
-                if let Some(r) = result {
+                state.host_roots_truncate(mark);
+                if let Some(r) = result? {
                     return Ok(r);
                 }
             }
@@ -1275,6 +1282,9 @@ fn list_map(
     let mut mapped = Vec::with_capacity(items.len());
     for item in items {
         let result = crate::vm::call_runtime_value_runtime(transform, &[*item], state, module, ctx.as_deref_mut())?;
+        // Results accumulated here are invisible to the collector while the
+        // next callback runs — pin each one (the caller restores the mark).
+        state.host_root_push(result);
         mapped.push(result);
     }
     let result = TypedList::Mixed(mapped);
@@ -1297,6 +1307,9 @@ fn list_reduce(
     let acc_fn = args[1];
     let mut acc = args[0];
     for item in items {
+        // Pin the running accumulator: it lives only in this Rust frame
+        // between callbacks (the caller restores the mark).
+        state.host_root_push(acc);
         acc = crate::vm::call_runtime_value_runtime(acc_fn, &[acc, *item], state, module, ctx.as_deref_mut())?;
     }
     Ok(Some(acc))

--- a/core/src/vm/exec.rs
+++ b/core/src/vm/exec.rs
@@ -28,7 +28,8 @@ pub use imports::import_runtime_export;
 pub use program::{
     ModuleFunctionArg, call_module_function_with_ctx, compile_program_module_with_ctx,
     execute_compiled_module_with_ctx, execute_module_artifact_with_ctx, execute_program, execute_program_with_ctx,
-    execute_program_with_ctx_and_budget, execute_program_with_ctx_and_limits, execute_source,
+    execute_program_with_ctx_and_budget, execute_program_with_ctx_and_gc_threshold,
+    execute_program_with_ctx_and_limits, execute_source,
 };
 #[cfg(test)]
 pub(crate) use runtime_callable::call_runtime_callable_test;

--- a/core/src/vm/exec/exec_tests.rs
+++ b/core/src/vm/exec/exec_tests.rs
@@ -16,4 +16,5 @@ mod calls;
 mod container;
 mod cross_heap;
 mod gc_cell_error;
+mod gc_host_roots;
 mod native;

--- a/core/src/vm/exec/exec_tests/gc_host_roots.rs
+++ b/core/src/vm/exec/exec_tests/gc_host_roots.rs
@@ -1,0 +1,60 @@
+//! Host-root regressions: values a native HOF holds in Rust across re-entrant
+//! VM calls (accumulated `map` results, the `reduce` accumulator, materialized
+//! item snapshots) must be pinned via `RuntimeModuleState::host_roots` or a
+//! collection inside the next callback frees them. Runs with the GC threshold
+//! pinned to 1 — the deterministic twin of `LK_GC_STRESS=1` — so a missing
+//! root fails in any test run (regression: `json_process.lk` under the CI GC
+//! stress job returned `[[Carol,293]] * 3` from a `map` building fresh lists).
+
+use super::*;
+use crate::syntax::{ParseOptions, parse_program_source};
+
+fn run_stressed(source: &str) -> crate::vm::ProgramResult {
+    let program = parse_program_source(source, ParseOptions::default()).expect("parse");
+    let mut ctx = VmContext::new();
+    crate::vm::execute_program_with_ctx_and_gc_threshold(&program, &mut ctx, 1).expect("execute stressed")
+}
+
+#[test]
+fn list_map_results_survive_gc_during_callbacks() {
+    let result = run_stressed(
+        "let out = [1, 2, 3].map(|u| [u, u * 2]);\n\
+         return out[0][0] + out[0][1] + out[1][1] + out[2][1];\n",
+    );
+    assert_eq!(result.returns, vec![RuntimeVal::Int(1 + 2 + 4 + 6)]);
+}
+
+#[test]
+fn list_reduce_heap_accumulator_survives_gc_during_callbacks() {
+    let result = run_stressed(
+        "let out = [1, 2, 3].reduce([], |acc, x| acc.concat([x * 2]));\n\
+         return out[0] + out[1] + out[2];\n",
+    );
+    assert_eq!(result.returns, vec![RuntimeVal::Int(2 + 4 + 6)]);
+}
+
+#[test]
+fn list_filter_materialized_long_string_items_survive_gc() {
+    // Long (>7 byte) strings are materialized onto the heap when the typed
+    // receiver list is snapshotted into `RuntimeVal` items — those items are
+    // host-held across the predicate callbacks. The predicate must allocate
+    // (the `+` concat) so a freed item's slot actually gets reused.
+    let result = run_stressed(
+        "let kept = [\"aaaaaaaaaaaa-one\", \"bbbbbbbbbbbb-two\", \"cccccccccccc-three\"]\n\
+             .filter(|s| (s + \"!\").len() > 17);\n\
+         return kept.len() == 1 && kept[0] == \"cccccccccccc-three\";\n",
+    );
+    assert_eq!(result.returns, vec![RuntimeVal::Bool(true)]);
+}
+
+#[test]
+fn nested_map_over_map_results_survives_gc() {
+    // The json_process.lk shape: an outer map whose callback allocates, over
+    // results that were themselves built by callbacks.
+    let result = run_stressed(
+        "let rows = [1, 2, 3].map(|u| [u, u * 10]);\n\
+         let tags = rows.map(|r| [r[0], r[1] + 1]);\n\
+         return tags[0][1] + tags[1][1] + tags[2][1];\n",
+    );
+    assert_eq!(result.returns, vec![RuntimeVal::Int(11 + 21 + 31)]);
+}

--- a/core/src/vm/exec/program.rs
+++ b/core/src/vm/exec/program.rs
@@ -87,25 +87,7 @@ pub fn execute_program_with_ctx_and_gc_threshold(
     gc_threshold: u32,
 ) -> Result<ProgramResult> {
     let module = compile_program_module_with_ctx(program, ctx)?;
-    ctx.truncate_call_stack(0);
-    let mut seed_heap = HeapStore::new();
-    seed_heap.set_gc_threshold(gc_threshold);
-    let globals = seed_module_globals(&module.globals, ctx, &mut seed_heap)?;
-    let register_count = module
-        .entry_function()
-        .map(|function| function.register_count)
-        .unwrap_or_default();
-    let result = Executor::new(register_count).run_shared_module_with_globals_and_heap_and_ctx(
-        Arc::clone(&module),
-        globals,
-        seed_heap,
-        ctx,
-    )?;
-    Ok(ProgramResult {
-        returns: result.returns,
-        state: result.state,
-        module,
-    })
+    execute_compiled_module_with_ctx_full(module, ctx, None, None, Some(gc_threshold))
 }
 
 fn execute_compiled_module_with_ctx_and_budget(
@@ -122,10 +104,23 @@ fn execute_compiled_module_with_ctx_inner(
     instruction_budget: Option<u64>,
     heap_object_limit: Option<usize>,
 ) -> Result<ProgramResult> {
+    execute_compiled_module_with_ctx_full(module, ctx, instruction_budget, heap_object_limit, None)
+}
+
+fn execute_compiled_module_with_ctx_full(
+    module: Arc<crate::vm::Module>,
+    ctx: &mut VmContext,
+    instruction_budget: Option<u64>,
+    heap_object_limit: Option<usize>,
+    gc_threshold: Option<u32>,
+) -> Result<ProgramResult> {
     // Start each top-level run with an empty traceback so a reused context
     // (REPL / embedded `Vm`) does not carry frames from a previous error.
     ctx.truncate_call_stack(0);
     let mut seed_heap = HeapStore::new();
+    if let Some(gc_threshold) = gc_threshold {
+        seed_heap.set_gc_threshold(gc_threshold);
+    }
     let globals = seed_module_globals(&module.globals, ctx, &mut seed_heap)?;
     let register_count = module
         .entry_function()

--- a/core/src/vm/exec/program.rs
+++ b/core/src/vm/exec/program.rs
@@ -76,6 +76,38 @@ pub fn execute_compiled_module_with_ctx(module: Arc<crate::vm::Module>, ctx: &mu
     execute_compiled_module_with_ctx_inner(module, ctx, None, None)
 }
 
+/// Execute with the heap's GC threshold pinned low so (nearly) every safepoint
+/// collects — the deterministic in-process twin of `LK_GC_STRESS=1`. Test-only
+/// surface for host-root regression tests (core and stdlib crates); not part
+/// of the public API.
+#[doc(hidden)]
+pub fn execute_program_with_ctx_and_gc_threshold(
+    program: &Program,
+    ctx: &mut VmContext,
+    gc_threshold: u32,
+) -> Result<ProgramResult> {
+    let module = compile_program_module_with_ctx(program, ctx)?;
+    ctx.truncate_call_stack(0);
+    let mut seed_heap = HeapStore::new();
+    seed_heap.set_gc_threshold(gc_threshold);
+    let globals = seed_module_globals(&module.globals, ctx, &mut seed_heap)?;
+    let register_count = module
+        .entry_function()
+        .map(|function| function.register_count)
+        .unwrap_or_default();
+    let result = Executor::new(register_count).run_shared_module_with_globals_and_heap_and_ctx(
+        Arc::clone(&module),
+        globals,
+        seed_heap,
+        ctx,
+    )?;
+    Ok(ProgramResult {
+        returns: result.returns,
+        state: result.state,
+        module,
+    })
+}
+
 fn execute_compiled_module_with_ctx_and_budget(
     module: Arc<crate::vm::Module>,
     ctx: &mut VmContext,

--- a/core/src/vm/gc.rs
+++ b/core/src/vm/gc.rs
@@ -81,6 +81,9 @@ impl RuntimeModuleState {
         // A first-class error value unwinding toward its `pcall` must survive GC
         // even though it is no longer on the VM stack (plan M2.2).
         roots.extend_values(self.pending_raise_root.iter());
+        // Values host (native) functions hold across re-entrant VM calls —
+        // e.g. an HOF's accumulated callback results (see `host_roots`).
+        roots.extend_values(&self.host_roots);
         roots
     }
 }
@@ -119,11 +122,12 @@ mod tests {
             RuntimeVal::Obj(HeapRef::new(3)),
         ];
         state.stack_top = 2;
+        state.host_root_push(RuntimeVal::Obj(HeapRef::new(5)));
         let extra = vec![RuntimeVal::Obj(HeapRef::new(4))];
 
         assert_eq!(
             state.gc_roots(&extra).into_refs(),
-            vec![HeapRef::new(1), HeapRef::new(2), HeapRef::new(4)]
+            vec![HeapRef::new(1), HeapRef::new(2), HeapRef::new(4), HeapRef::new(5)]
         );
     }
 

--- a/core/src/vm/runtime.rs
+++ b/core/src/vm/runtime.rs
@@ -35,6 +35,13 @@ pub struct RuntimeModuleState {
     /// carried as an error survives collection at the native-call safepoints hit
     /// during unwinding (plan M2.2). Cleared once `pcall` extracts it.
     pub(crate) pending_raise_root: Option<RuntimeVal>,
+    /// Values a host (native) function must keep alive across re-entrant VM
+    /// calls: a stdlib HOF accumulating callback results in a Rust `Vec` holds
+    /// heap references invisible to the collector, so a safepoint inside the
+    /// next callback would free them (`GC stress` exposes this
+    /// deterministically). Hosts push via `host_root_push`/`host_roots_extend`
+    /// and restore their `host_roots_mark` on every exit path.
+    pub(crate) host_roots: Vec<RuntimeVal>,
     /// Live LK call depth. Lives in the shared state (not the executor) so it
     /// keeps accumulating across native→VM re-entries (pcall, stdlib HOFs, the
     /// Tier 1 bridge), which each construct a fresh executor: the runaway-
@@ -54,6 +61,7 @@ impl RuntimeModuleState {
             stack_top: 0,
             inline_caches: InlineCaches::default(),
             pending_raise_root: None,
+            host_roots: Vec::new(),
             call_depth: 0,
         }
     }
@@ -62,6 +70,34 @@ impl RuntimeModuleState {
     /// treated as a GC root until `pcall` recovers it (plan M2.2).
     pub fn set_pending_raise_root(&mut self, value: Option<RuntimeVal>) {
         self.pending_raise_root = value;
+    }
+
+    /// Current host-root stack depth. Take a mark before pushing host roots
+    /// and restore it with [`Self::host_roots_truncate`] on every exit path
+    /// (including errors), or the pins outlive their host call.
+    #[inline]
+    pub fn host_roots_mark(&self) -> usize {
+        self.host_roots.len()
+    }
+
+    /// Pin a value a host function holds across a re-entrant VM call so the
+    /// collector treats it as a root (see the `host_roots` field docs).
+    #[inline]
+    pub fn host_root_push(&mut self, value: RuntimeVal) {
+        self.host_roots.push(value);
+    }
+
+    /// Pin every value of a host-held snapshot (e.g. a materialized list of
+    /// items an HOF iterates while calling back into the VM).
+    #[inline]
+    pub fn host_roots_extend<'a>(&mut self, values: impl IntoIterator<Item = &'a RuntimeVal>) {
+        self.host_roots.extend(values.into_iter().copied());
+    }
+
+    /// Drop every host root pinned after `mark`.
+    #[inline]
+    pub fn host_roots_truncate(&mut self, mark: usize) {
+        self.host_roots.truncate(mark);
     }
 
     pub fn root_refs<'a>(&self, extra_roots: impl IntoIterator<Item = &'a RuntimeVal>) -> Vec<crate::val::HeapRef> {
@@ -363,6 +399,32 @@ impl<'a> NativeRuntime<'a> {
     #[inline]
     pub fn ctx_mut(&mut self) -> Option<&mut VmContext> {
         self.ctx.as_deref_mut()
+    }
+
+    /// Host-root mark for `Self::host_root_push` (see
+    /// `RuntimeModuleState::host_roots`). `Parts` storage has no state to pin
+    /// into, so the mark is 0 and pushes are dropped — re-entrant VM calls
+    /// that could collect the caller's heap only happen with `State` storage.
+    #[inline]
+    pub fn host_roots_mark(&self) -> usize {
+        match &self.storage {
+            NativeRuntimeStorage::State(state) => state.host_roots_mark(),
+            NativeRuntimeStorage::Parts { .. } => 0,
+        }
+    }
+
+    #[inline]
+    pub fn host_root_push(&mut self, value: RuntimeVal) {
+        if let NativeRuntimeStorage::State(state) = &mut self.storage {
+            state.host_root_push(value);
+        }
+    }
+
+    #[inline]
+    pub fn host_roots_truncate(&mut self, mark: usize) {
+        if let NativeRuntimeStorage::State(state) = &mut self.storage {
+            state.host_roots_truncate(mark);
+        }
     }
 }
 

--- a/handoff.md
+++ b/handoff.md
@@ -16,9 +16,29 @@
   raise 前缀统一 · docs/macros.md · select Condvar 唤醒 · lower 三张声明表 ·
   fixpoint 省 clone · unsupported.lk 全翻转。细节 progress.md「打磨轮」。
 
-## 剩余(全部可选/留档,无进行中必做项)
+## 进行中:Tier 1 收尾三阶段(2026-07-09 起,计划文件 playful-meandering-sloth.md)
 
-- **Tier 1 混合执行**(大项,需单独立项):同程序 native+VM 函数混合、native↔VM ABI 桥。
+**更正**:Tier 1 hybrid v1 早已全套落地(opt-in `LK_AOT_HYBRID=1`,五子步完成,
+docs/llvm/tier1-hybrid.md)——此前 handoff 把它列为"待做大项"是误读。真实剩余:
+- **A ✅ 修 correctness 夜跑三回归**(07-07 起连红 5 轮):A0 harness 补 stderr ·
+  A1 fuzz 超时=staticlib 冷构建吃进 per-case 60s(预热+CI prebuild)· A2 sanitized
+  分歧=LSan 杀缓冲 stdout(JmpBuf 备用槽复用修真泄漏 + 差分 detect_leaks=0)·
+  A3 GC stress VM 真 bug=宿主 HOF 累积值无 root(**host_roots 机制**,
+  map/filter/reduce/stream 全钉 + 确定性 stress 回归基建)。细节 progress.md
+  「Tier 1 收尾轮」。分支 fix/correctness-nightly-regressions,PR 待开/合并。
+- **B 待做:翻默认**(前置=PR-A 合并 + workflow_dispatch 触发 correctness ≥3 轮全绿):
+  lower :1144 is_none_or · hybrid_off_by_default 翻转 · fuzz 删显式 env ·
+  aot_coverage.sh 钉 LK_AOT_HYBRID=0 · tier1-hybrid.md 状态行(现仍写 not
+  implemented,过时)+ CLAUDE.md。
+- **C 待做:v2 桥接返回值**(C1-C7 commit 切分见计划文件):`lk_hybrid_call_r`
+  返回 LkDyn by-value({i64,i64},与 dyn.* ABI 同通路)· MIR CallVm{dst:Option}
+  · dst 绑 Ty::Dyn · core call_module_function_owned(**关键**:现 with_ctx 返回
+  的 Obj 指向调用内局部 heap,v1 discard 掩盖悬空)· 容器深转换经 wrapper 注入
+  lkrt 构造表(lkrt 铁律不破)· C6 raise 经注入指针 longjmp 进 native try ·
+  fuzz hybrid 帮手已退化(try/catch 现可原生 lower)需换动态格式串+断言桥覆盖。
+
+## 剩余(可选/留档)
+
 - goroutine 死锁检测(泄漏检测之外)。
 - lkrt 静态库 sanitizer 重编(-Zbuild-std 触发 E0152 留档;现靠混合配置差分兜底)。
 - FFI 增强:ergonomic Value 转换层 · register_module 命名空间 · rooted handle。

--- a/lkrt/src/panic.rs
+++ b/lkrt/src/panic.rs
@@ -33,6 +33,55 @@ unsafe extern "C" {
 #[repr(C, align(16))]
 struct JmpBuf([u8; 512]);
 
+/// The jump buffer of the last raise, parked instead of freed: `_longjmp`
+/// still reads the buffer after the handler pop, so freeing at raise time
+/// races the jump — but once the landing pad runs the buffer is dead. It is
+/// reclaimed (reused or freed) at the next `try` push, the next parked
+/// raise, or thread exit, so raise-heavy programs stay at one buffer per
+/// thread instead of leaking 512 bytes per raise (LeakSanitizer flagged the
+/// old leak, and its exit-time report also swallowed buffered stdout).
+struct SpareJmpBuf(Cell<*mut JmpBuf>);
+
+impl SpareJmpBuf {
+    /// Takes the parked buffer for reuse, or allocates fresh. Safe to reuse:
+    /// any longjmp through the parked buffer landed before the control flow
+    /// pushing a new `try` frame could run.
+    fn take_or_alloc(&self) -> Box<JmpBuf> {
+        let parked = self.0.replace(core::ptr::null_mut());
+        if parked.is_null() {
+            Box::new(JmpBuf([0; 512]))
+        } else {
+            // SAFETY: parked pointers come from `Box::into_raw` in `park`
+            // and are handed out exactly once (replaced with null above).
+            unsafe { Box::from_raw(parked) }
+        }
+    }
+
+    /// Parks `buf` for the raise in flight and returns the raw pointer the
+    /// longjmp reads. A previously parked buffer is dead by now (its landing
+    /// pad ran before this raise could execute) and is freed here.
+    fn park(&self, buf: Box<JmpBuf>) -> *mut JmpBuf {
+        let raw = Box::into_raw(buf);
+        let previous = self.0.replace(raw);
+        if !previous.is_null() {
+            // SAFETY: `previous` came from `Box::into_raw` in an earlier
+            // `park`; its longjmp completed before this code could run.
+            drop(unsafe { Box::from_raw(previous) });
+        }
+        raw
+    }
+}
+
+impl Drop for SpareJmpBuf {
+    fn drop(&mut self) {
+        let parked = self.0.replace(core::ptr::null_mut());
+        if !parked.is_null() {
+            // SAFETY: no longjmp is in flight during thread teardown.
+            drop(unsafe { Box::from_raw(parked) });
+        }
+    }
+}
+
 thread_local! {
     /// Live `try` frames, innermost last. The boxing is load-bearing (not a
     /// `vec_box` accident): `_setjmp` captured the buffer's address, which
@@ -41,15 +90,18 @@ thread_local! {
     static HANDLERS: RefCell<Vec<Box<JmpBuf>>> = const { RefCell::new(Vec::new()) };
     /// The value carried by the in-flight (or just-caught) raise.
     static CURRENT_ERROR: Cell<LkDyn> = const { Cell::new(LkDyn::NIL) };
+    /// See [`SpareJmpBuf`].
+    static SPARE_BUF: SpareJmpBuf = const { SpareJmpBuf(Cell::new(core::ptr::null_mut())) };
 }
 
 /// Enters a `try` frame: pushes a fresh jump buffer and returns its address
 /// (the generated code passes it to `_setjmp`).
 #[unsafe(no_mangle)]
 pub extern "C" fn lkrt_rt_try_push() -> *mut c_void {
+    let fresh = SPARE_BUF.with(SpareJmpBuf::take_or_alloc);
     HANDLERS.with(|handlers| {
         let mut handlers = handlers.borrow_mut();
-        handlers.push(Box::new(JmpBuf([0; 512])));
+        handlers.push(fresh);
         let buf: &mut JmpBuf = handlers.last_mut().expect("just pushed");
         buf as *mut JmpBuf as *mut c_void
     })
@@ -72,15 +124,15 @@ pub extern "C" fn lkrt_rt_current_error() -> LkDyn {
 
 fn raise_current(value: LkDyn) -> ! {
     CURRENT_ERROR.with(|slot| slot.set(value));
-    let target = HANDLERS.with(|handlers| {
-        let mut handlers = handlers.borrow_mut();
-        handlers.pop().map(|buf| Box::into_raw(buf) as *mut c_void)
-    });
+    let target = HANDLERS.with(|handlers| handlers.borrow_mut().pop());
     match target {
-        // The buffer is intentionally leaked (arena model): the landing pad
-        // may still be on the stack that owns it, freeing here would race
-        // the longjmp.
-        Some(buf) => unsafe { _longjmp(buf, 1) },
+        // Park (not free) the buffer: the longjmp still reads it. Bounded at
+        // one parked buffer per thread; reclaimed at the next push/park/
+        // thread end (see `SpareJmpBuf`).
+        Some(buf) => {
+            let raw = SPARE_BUF.with(|spare| spare.park(buf));
+            unsafe { _longjmp(raw as *mut c_void, 1) }
+        }
         None => crate::abi::flush_and_abort(),
     }
 }
@@ -169,4 +221,28 @@ mod tests {
     // The setjmp/longjmp round trip itself is exercised end-to-end by the
     // native differential corpus (Rust tests cannot call `_setjmp` safely);
     // the no-handler path is the existing abort, covered there too.
+}
+
+// No `_setjmp` involved — runs under Miri too (Stacked Borrows over the
+// park/reuse/free raw-pointer choreography).
+#[cfg(test)]
+mod spare_buf_tests {
+    use super::*;
+
+    #[test]
+    fn spare_jmp_buf_parks_reuses_and_frees() {
+        let spare = SpareJmpBuf(Cell::new(core::ptr::null_mut()));
+        // Nothing parked: allocates fresh.
+        let first = spare.take_or_alloc();
+        let first_addr = &*first as *const JmpBuf;
+        // Parking hands back the same address for the longjmp.
+        assert_eq!(spare.park(first), first_addr as *mut JmpBuf);
+        // Reuse: the parked buffer comes back instead of a fresh allocation.
+        let reused = spare.take_or_alloc();
+        assert_eq!(&*reused as *const JmpBuf, first_addr);
+        // Parking twice frees the previous buffer (no growth) — Miri/ASan
+        // validate the frees; Drop reclaims whatever stays parked.
+        spare.park(reused);
+        spare.park(Box::new(JmpBuf([0; 512])));
+    }
 }

--- a/progress.md
+++ b/progress.md
@@ -926,3 +926,41 @@ no_std + dist bench 噪声带(0.986-1.076x)。
   "ha"*3 编译器常量折叠,无需改动(probe 钉实)。
 - bench 全程噪声带(0.990-1.011x)。**唯一留档遗留:goroutine
   死锁检测(超范围)。**
+
+## Tier 1 收尾轮:correctness 夜跑三回归修复(2026-07-09,分支 fix/correctness-nightly-regressions)
+
+背景:correctness.yml 自 07-07 深覆盖合并起连续 5 轮红,三个失败签名
+稳定。计划文件 `~/.claude/plans/playful-meandering-sloth.md`(A 修回归 →
+B 翻 LK_AOT_HYBRID 默认 → C v2 桥接返回值,用户裁决全做)。
+
+- **A0**:差分 harness 分歧报告附双侧 stderr+exit code(examples 此前
+  只打两个 stdout,CI 日志看不到 VM 侧真实错误)——A2 排查当场受益。
+- **A3(真 VM bug,GC stress 下 json_process 空 stdout)**:list.map 在
+  Rust Vec 累积回调结果,回调内 safepoint 收集 → 堆槽复用 → 三条
+  summaries 全别名末元素。**机制修复**:RuntimeModuleState::host_roots
+  栈(gc_roots 纳入,类比 pending_raise_root)+ mark/push/extend/truncate
+  纪律 + NativeRuntime 转发;钉 core list_map/filter(长串物化快照)/
+  reduce(acc 保险)+ iter.map/filter/reduce + stream collect_remaining。
+  **回归基建**:execute_program_with_ctx_and_gc_threshold(threshold=1,
+  LK_GC_STRESS 的进程内确定性孪生,doc(hidden) 供跨 crate 测试)+
+  core 4 测 + stdlib 4 测(map/filter/stream 三例验证无修复必红)。
+  **cursor 链路论证安全**:stream Iterate/Map cursor 的中间值恰与回调
+  实参别名(实参=root),collect 累积是唯一的洞。
+- **A1(fuzz 每晚一例 60s 超时,案例号随 seed 漂移)**:根因=lk compile
+  子进程内 ensure_lk_api_staticlib 的 cargo release 全量构建(冷缓存
+  ~4.5min)整个算进首个需桥/回退案例的 per-case 超时;fresh-seed job
+  只编 debug 依赖 + rust-cache 失败不存 → 每晚从零自锁。日志实锤
+  (超时前大片 release Compiling);出事 seed 重放(seed+413 单例)
+  0.5s 过,形状无辜。修:harness 案例循环前免超时预热(镜像同款
+  cargo 命令)+ correctness.yml 四 job prebuild step + cache-on-failure。
+- **A2(chan sanitized 分歧)**:真相=LSan exit-time 报告改非零退出码
+  且 _exit 吞缓冲 stdout → "native 空输出"。两源:① raise_current 每
+  raise 有意泄漏 512B JmpBuf(真·无界泄漏);② longjmp 越过 Rust 帧的
+  普通临时量(select 路径 40B Vec)——sjlj 设计内泄漏,不可逐个消除。
+  修:① SpareJmpBuf 线程本地备用槽(park→下次 push 复用→再 park 释放
+  前一个→线程退出 Drop 回收,每线程至多 1 缓冲,Miri SB 验证);
+  ② 三差分 harness native 运行 ASAN_OPTIONS=detect_leaks=0(留档:
+  arena 模型下 LSan 无意义),ASan UAF/越界全开。
+- 验证:sanitized 手写 12/12 · examples 51/51 · fuzz 120/120 ·
+  LK_GC_STRESS 下 core/stdlib/cli 全绿(CI 原命令)· miri lkrt ·
+  clippy --all-targets 0 · fmt 0 · aot_coverage 51/51。

--- a/stdlib/crates/iter/src/lib.rs
+++ b/stdlib/crates/iter/src/lib.rs
@@ -72,18 +72,18 @@ impl IterModule {
         let values = args.as_slice();
         let input = list_snapshot_arg(&values[0], runtime.heap(), "iter.reduce first argument")?;
         let mut acc = values[1];
-        // Pin the running accumulator: it lives only in this Rust frame
-        // between callbacks (host_roots discipline).
-        let mark = runtime.host_roots_mark();
-        let run = input.for_each_item(|item| {
+        input.for_each_item(|item| {
             let value = item.into_runtime_value(runtime.heap_mut());
             let previous = std::mem::replace(&mut acc, RuntimeVal::Nil);
+            // Pin the accumulator only for the callback that consumes it
+            // (per-iteration mark/truncate keeps `host_roots` O(1)).
+            let iteration_mark = runtime.host_roots_mark();
             runtime.host_root_push(previous);
-            acc = call_callable(&values[2], &[previous, value], runtime, "iter.reduce third argument")?;
+            let result = call_callable(&values[2], &[previous, value], runtime, "iter.reduce third argument");
+            runtime.host_roots_truncate(iteration_mark);
+            acc = result?;
             Ok(())
-        });
-        runtime.host_roots_truncate(mark);
-        run?;
+        })?;
         Ok(acc)
     }
 

--- a/stdlib/crates/iter/src/lib.rs
+++ b/stdlib/crates/iter/src/lib.rs
@@ -25,16 +25,18 @@ impl IterModule {
         let values = args.as_slice();
         let input = list_snapshot_arg(&values[0], runtime.heap(), "iter.map first argument")?;
         let mut out = Vec::with_capacity(input.len());
-        input.for_each_item(|item| {
+        // Accumulated callback results are host-held Rust values: pin each one
+        // or a GC inside the next callback frees it (host_roots discipline).
+        let mark = runtime.host_roots_mark();
+        let run = input.for_each_item(|item| {
             let value = item.into_runtime_value(runtime.heap_mut());
-            out.push(call_callable(
-                &values[1],
-                &[value],
-                runtime,
-                "iter.map second argument",
-            )?);
+            let result = call_callable(&values[1], &[value], runtime, "iter.map second argument")?;
+            runtime.host_root_push(result);
+            out.push(result);
             Ok(())
-        })?;
+        });
+        runtime.host_roots_truncate(mark);
+        run?;
         runtime_list(out, runtime.heap_mut())
     }
 
@@ -43,7 +45,10 @@ impl IterModule {
         let values = args.as_slice();
         let input = list_snapshot_arg(&values[0], runtime.heap(), "iter.filter first argument")?;
         let mut out = Vec::with_capacity(input.len());
-        input.for_each_item(|item| {
+        // Kept items can be fresh heap objects materialized off the snapshot
+        // (long strings) — pin them across the remaining predicate callbacks.
+        let mark = runtime.host_roots_mark();
+        let run = input.for_each_item(|item| {
             let value = item.into_runtime_value(runtime.heap_mut());
             let keep = call_callable(
                 &values[1],
@@ -52,10 +57,13 @@ impl IterModule {
                 "iter.filter second argument",
             )?;
             if truthy(&keep) {
+                runtime.host_root_push(value);
                 out.push(value);
             }
             Ok(())
-        })?;
+        });
+        runtime.host_roots_truncate(mark);
+        run?;
         runtime_list(out, runtime.heap_mut())
     }
 
@@ -64,12 +72,18 @@ impl IterModule {
         let values = args.as_slice();
         let input = list_snapshot_arg(&values[0], runtime.heap(), "iter.reduce first argument")?;
         let mut acc = values[1];
-        input.for_each_item(|item| {
+        // Pin the running accumulator: it lives only in this Rust frame
+        // between callbacks (host_roots discipline).
+        let mark = runtime.host_roots_mark();
+        let run = input.for_each_item(|item| {
             let value = item.into_runtime_value(runtime.heap_mut());
             let previous = std::mem::replace(&mut acc, RuntimeVal::Nil);
+            runtime.host_root_push(previous);
             acc = call_callable(&values[2], &[previous, value], runtime, "iter.reduce third argument")?;
             Ok(())
-        })?;
+        });
+        runtime.host_roots_truncate(mark);
+        run?;
         Ok(acc)
     }
 

--- a/stdlib/crates/stream/src/lib.rs
+++ b/stdlib/crates/stream/src/lib.rs
@@ -81,18 +81,27 @@ trait StreamCursor {
     fn collect_remaining(&mut self, limit: Option<i64>, runtime: &mut NativeRuntime<'_>) -> Result<TypedList> {
         let mut out = Vec::new();
         let mut taken = 0i64;
-        loop {
-            if let Some(limit) = limit
-                && taken >= limit
-            {
-                break;
+        // Collected values are host-held while `next` re-enters the VM for
+        // map/filter callbacks — pin each one (host_roots discipline).
+        let mark = runtime.host_roots_mark();
+        let run = (|| -> Result<()> {
+            loop {
+                if let Some(limit) = limit
+                    && taken >= limit
+                {
+                    break;
+                }
+                let Some(value) = self.next(runtime)? else {
+                    break;
+                };
+                runtime.host_root_push(value);
+                out.push(value);
+                taken += 1;
             }
-            let Some(value) = self.next(runtime)? else {
-                break;
-            };
-            out.push(value);
-            taken += 1;
-        }
+            Ok(())
+        })();
+        runtime.host_roots_truncate(mark);
+        run?;
         Ok(crate::typed_list_from_values(out, runtime.heap()))
     }
 }

--- a/stdlib/src/gc_stress_test.rs
+++ b/stdlib/src/gc_stress_test.rs
@@ -1,0 +1,92 @@
+//! Host-root regressions over stdlib modules (`iter`, `stream`, `encoding`):
+//! results a native HOF accumulates in Rust across VM callbacks must be pinned
+//! via the host-roots discipline (see `RuntimeModuleState::host_roots`). Runs
+//! with the GC threshold pinned to 1 — the deterministic in-process twin of
+//! the CI `LK_GC_STRESS=1` job that caught `json_process.lk` returning
+//! `[[Carol,293]] * 3` from a `map` building fresh lists.
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use anyhow::Result;
+    use lk_core::{
+        module::ModuleRegistry,
+        stmt::{ModuleResolver, stmt_parser::StmtParser},
+        token::Tokenizer,
+        val::RuntimeVal,
+        vm::{ProgramResult, VmContext},
+    };
+
+    fn run_stressed(source: &str) -> Result<ProgramResult> {
+        let tokens = Tokenizer::tokenize(source)?;
+        let mut parser = StmtParser::new(&tokens);
+        let program = parser.parse_program()?;
+
+        let mut registry = ModuleRegistry::new();
+        crate::register_stdlib_modules(&mut registry)?;
+        let resolver = Arc::new(ModuleResolver::with_registry(registry));
+        let mut env = VmContext::new().with_resolver(resolver);
+        lk_core::vm::execute_program_with_ctx_and_gc_threshold(&program, &mut env, 1)
+    }
+
+    #[test]
+    fn iter_map_results_survive_gc_during_callbacks() -> Result<()> {
+        let result = run_stressed(
+            r#"
+            use iter;
+            let out = iter.map([1, 2, 3], |u| [u, u * 2]);
+            return out[0][0] + out[0][1] + out[1][1] + out[2][1];
+            "#,
+        )?;
+        assert_eq!(result.returns, vec![RuntimeVal::Int(1 + 2 + 4 + 6)]);
+        Ok(())
+    }
+
+    #[test]
+    fn iter_filter_and_reduce_survive_gc_during_callbacks() -> Result<()> {
+        let result = run_stressed(
+            r#"
+            use iter;
+            let kept = iter.filter(["aaaaaaaaaaaa-one", "bbbbbbbbbbbb-two", "cccccccccccc-three"],
+                                   |s| (s + "!").len() > 17);
+            let folded = iter.reduce([1, 2, 3], [], |acc, x| acc.concat([x * 2]));
+            return kept.len() == 1 && kept[0] == "cccccccccccc-three"
+                && folded[0] + folded[1] + folded[2] == 12;
+            "#,
+        )?;
+        assert_eq!(result.returns, vec![RuntimeVal::Bool(true)]);
+        Ok(())
+    }
+
+    #[test]
+    fn stream_collect_survives_gc_during_pipeline_callbacks() -> Result<()> {
+        let result = run_stressed(
+            r#"
+            use stream;
+            let s = stream.from_list([1, 2, 3]);
+            let mapped = stream.map(s, |u| [u, u * 2]);
+            let out = stream.collect(mapped);
+            return out[0][0] + out[0][1] + out[1][1] + out[2][1];
+            "#,
+        )?;
+        assert_eq!(result.returns, vec![RuntimeVal::Int(1 + 2 + 4 + 6)]);
+        Ok(())
+    }
+
+    #[test]
+    fn json_process_shape_survives_gc() -> Result<()> {
+        // The exact shape that failed in CI: json.parse feeding chained `map`
+        // callbacks that build fresh lists.
+        let result = run_stressed(
+            r#"
+            use { json } from encoding;
+            let data = json.parse("{ \"users\": [{ \"name\": \"Alice\", \"scores\": [95, 87] }, { \"name\": \"Bob\", \"scores\": [78, 85] }] }");
+            let summaries = data.users.map(|u| [u.name, u.scores.reduce(0, |a, b| a + b)]);
+            return summaries[0][0] == "Alice" && summaries[0][1] == 182
+                && summaries[1][0] == "Bob" && summaries[1][1] == 163;
+            "#,
+        )?;
+        assert_eq!(result.returns, vec![RuntimeVal::Bool(true)]);
+        Ok(())
+    }
+}

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -32,6 +32,8 @@ mod chan_semantics_test;
 #[cfg(test)]
 mod datetime_test;
 #[cfg(test)]
+mod gc_stress_test;
+#[cfg(test)]
 mod globals_test;
 #[cfg(test)]
 mod math_test;


### PR DESCRIPTION
## 概要

correctness.yml 自 07-07 深覆盖合并起连续 5 轮红,三个失败签名稳定。本 PR 三个根因全部修复 + harness 增强,是 Tier 1 收尾三阶段(A 修回归 → B 翻默认 → C v2 桥接返回值)的第一步。

### A3 — 真 VM bug:宿主 HOF 累积值无 GC root(`f0b3c15`)
GC stress 下 `json_process.lk` 三条 summaries 全变末元素:`list.map` 在 Rust Vec 里累积回调结果,回调内 safepoint 收集 → 堆槽复用 → 全部别名同一对象。
**机制修复**:`RuntimeModuleState::host_roots` 栈(`gc_roots` 纳入,类比 `pending_raise_root`)+ mark/push/extend/truncate 纪律 + `NativeRuntime` 转发;钉 core `list_map`/`list_filter`(长串物化快照)/`list_reduce`(保险)+ `iter.map/filter/reduce` + `stream collect_remaining`。
**回归基建**:`execute_program_with_ctx_and_gc_threshold`(threshold=1,`LK_GC_STRESS` 的进程内确定性孪生)+ core 4 测 + stdlib 4 测,其中 5 例验证过"无修复必红"。

### A1 — fuzz 每晚一例 native compile 60s 超时(`ce4b571`)
根因:`lk compile` 子进程内 `ensure_lk_api_staticlib` 的 cargo release 全量构建(冷缓存 ~4.5min)整个算进首个需桥/回退案例的 per-case 超时;fresh-seed job 只编 debug 依赖 + rust-cache 失败不存缓存 → 每晚从零、自锁连红。日志实锤(超时前大片 release `Compiling`);出事 seed 精确重放(seed+413 单例)0.5s 通过,案例形状无辜。
修:harness 案例循环前免超时预热 + correctness.yml 四 job prebuild step + `cache-on-failure: true`。

### A2 — sanitized 差分分歧 = LSan 杀掉缓冲 stdout(`295cd8f`)
真相:LSan exit-time 报告改非零退出码且 `_exit` 吞缓冲 stdout → 表现为 native 空输出。两个泄漏源:① `raise_current` 每次 raise 有意泄漏 512B JmpBuf(同时是真·无界泄漏);② longjmp 越过 Rust 帧的普通临时量(sjlj 设计内泄漏,不可逐个消除)。
修:① `SpareJmpBuf` 线程本地备用槽(park → 下次 push 复用 → 再 park 释放前一个 → 线程退出 Drop 回收,每线程至多 1 缓冲,Miri SB 验证);② 三差分 harness 的 native 运行 `ASAN_OPTIONS=detect_leaks=0`(arena 模型下 LSan 无意义,注释留档),ASan UAF/越界检测全开。

### A0 — harness 增强(`a9920c2`)
差分分歧报告附双侧 stderr + exit code(此前 CI 日志看不到 VM 侧真实错误)——A2 排查当场受益。

## 验证

- sanitized 差分:手写 12/12 · examples 51/51 · fuzz 120/120
- `LK_GC_STRESS=1` 下 core/stdlib/cli 全绿(CI 原命令)
- miri -p lkrt(Stacked Borrows)全绿
- workspace `--all-features` + `RUSTFLAGS=-D warnings` 0 失败 · clippy `--all-targets` 0 · fmt 0
- `aot_coverage.sh` 51/51 不变 · bench 几何均值 1.013x(噪声带)

合并后请手动触发数轮 `gh workflow run correctness.yml` 验证全绿(阶段 B 翻默认的前置)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 扩展了 GC 压力与差分测试覆盖，强化迭代、高阶回调与流处理等场景的稳定性。
* **Bug Fixes**
  * 修复了回调期间与 GC 交互导致的结果/中间值被错误回收问题。
  * 改进了原生执行的泄漏检测处理，降低 ASan 相关噪声对结论的干扰。
* **Testing**
  * 差分测试诊断增强：失败时同时输出退出码与两侧 stderr，更易定位分歧原因。
  * correctness/fuzz 等作业增加构建预热与缓存行为优化，减少超时与编译引发的偏差。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->