### PR TITLE
feat: LK_AOT_HYBRID 翻默认 —— Tier 1 hybrid 默认开启(B)

### DIFF
--- a/aot/lower/src/lib.rs
+++ b/aot/lower/src/lib.rs
@@ -1138,10 +1138,10 @@ fn trait_env_prescan(module: &lk_core::vm::ModuleData) -> TraitEnv {
 }
 
 pub fn lower(artifact: &ModuleArtifact) -> Result<MirModule, Unsupported> {
-    // Opt-in until the CLI links the bridge runtime (tier1-hybrid.md sub-step
-    // ④): emitting `CallVm` without the lk-api staticlib linked would turn
-    // graceful `Unsupported` fallbacks into link errors.
-    let hybrid = std::env::var_os("LK_AOT_HYBRID").is_some_and(|value| value != "0");
+    // Default-on since the nightly correctness rounds went green on v1+v2
+    // (tier1-hybrid.md): `LK_AOT_HYBRID=0` opts out (pure whole-module
+    // native-or-fallback, e.g. the coverage script's metric).
+    let hybrid = std::env::var_os("LK_AOT_HYBRID").is_none_or(|value| value != "0");
     lower_with_hybrid(artifact, hybrid)
 }
 

--- a/aot/lower/tests/hybrid_lowering.rs
+++ b/aot/lower/tests/hybrid_lowering.rs
@@ -121,11 +121,13 @@ fn hybrid_rejects_a_global_touching_callee() {
 }
 
 #[test]
-fn hybrid_off_by_default() {
-    // `lower()` keeps the pre-hybrid behavior until the CLI links the bridge
-    // runtime (LK_AOT_HYBRID opt-in): same program, whole-module fallback.
+fn hybrid_on_by_default() {
+    // `lower()` bridges by default; `LK_AOT_HYBRID=0` opts out (the same
+    // env-guard discipline as the old opt-in test: skip when the ambient
+    // process env pins the flag either way).
     let artifact = artifact(REPORT_PROGRAM);
     if std::env::var_os("LK_AOT_HYBRID").is_none() {
-        lk_aot_lower::lower(&artifact).expect_err("hybrid stays opt-in by default");
+        let mir = lk_aot_lower::lower(&artifact).expect("hybrid is on by default");
+        assert_eq!(mir.vm_functions.len(), 1, "the helper bridges by default");
     }
 }

--- a/cli/tests/aot_fuzz_differential_test.rs
+++ b/cli/tests/aot_fuzz_differential_test.rs
@@ -877,15 +877,12 @@ fn run_case(dir: &std::path::Path, name: &str, source: &str, seed: u64, expect_h
         context("VM rejected a generated program")
     );
 
-    // MIR-gated native compile: either it lowers (fully native or Tier 1
-    // hybrid — LK_AOT_HYBRID exercises the bridge on the generated hybrid
-    // helpers), or it must fail with a graceful Unsupported reason (lower()
-    // totality) — never a panic.
+    // MIR-gated native compile under the *real default* (hybrid on): either
+    // it lowers (fully native or Tier 1 hybrid — the generated hybrid
+    // helpers exercise the bridge), or it must fail with a graceful
+    // Unsupported reason (lower() totality) — never a panic.
     let mut exe_cmd = Command::new(bin_path());
-    exe_cmd
-        .current_dir(dir)
-        .args(["compile", &file])
-        .env("LK_AOT_HYBRID", "1");
+    exe_cmd.current_dir(dir).args(["compile", &file]);
     let exe = output_with_timeout(exe_cmd, "native compile", &context("native compile"));
     let exe_stderr = String::from_utf8_lossy(&exe.stderr).into_owned();
     assert!(

--- a/docs/llvm/tier1-hybrid.md
+++ b/docs/llvm/tier1-hybrid.md
@@ -1,8 +1,10 @@
 # Tier 1 Hybrid: Per-Function VM Fallback (Design)
 
-Status: **implemented — v1 (one-way, results discarded) and the v2 return
-bridge (see the "v2" section below)**; opt-in via `LK_AOT_HYBRID=1` until the
-nightly correctness rounds green-light the default flip. This document fixes
+Status: **implemented and on by default — v1 (one-way, results discarded)
+and the v2 return bridge (see the "v2" section below)**; `LK_AOT_HYBRID=0`
+opts out (whole-module native-or-Tier-0, e.g. the coverage script's metric).
+The default flipped after consecutive green nightly correctness rounds over
+v1+v2. This document fixes
 the architecture decisions; the staged sub-steps at the bottom are the
 implementation record. Key anchors today: `aot/lower/src/lib.rs`
 (eligibility + mark/rerun fixpoint), `aot/mir` (`Inst::CallVm { dst }`),

--- a/scripts/aot_coverage.sh
+++ b/scripts/aot_coverage.sh
@@ -6,6 +6,10 @@
 # Output: per-file OK/FAIL lines on stdout, reason ranking on stderr.
 set -u
 LK_BIN="${LK_BIN:-./target/debug/lk}"
+# The metric is *pure native lowering* coverage: with hybrid on (the default
+# since v2), a bridged program would count OK and mask a native-coverage
+# regression — pin it off for the scan.
+export LK_AOT_HYBRID=0
 total=0
 ok=0
 reasons_file="$(mktemp)"


### PR DESCRIPTION
## 概要

Tier 1 收尾三阶段的最后一步(A 修回归 ✅ #22 → C v2 桥接返回值 ✅ #23 → **B 本 PR**)。

**前置已满足**:correctness.yml 连续 4 轮全绿——#22 合并后 push 轮 + 两轮手动 dispatch(均在修复后的 main)+ #23 合并后 push 轮(含 v2 桥全部代码,GC stress / ASan/UBSan 差分 / 500 例 fresh-seed fuzz / Miri 全过)。

## 改动(单 commit,便于 revert)

- `aot/lower/src/lib.rs`:`lower()` 的 hybrid 门 `is_some_and` → `is_none_or`——**默认开**,`LK_AOT_HYBRID=0` opt-out(纯 whole-module native-or-Tier-0 行为)。
- `hybrid_off_by_default` 测试翻转为 `hybrid_on_by_default`(沿用 env-guard 纪律)。
- fuzz 差分删显式 `LK_AOT_HYBRID=1`,改测真实默认。
- `scripts/aot_coverage.sh` 钉 `LK_AOT_HYBRID=0`:覆盖率的度量语义是**纯原生 lowering**,防止可桥程序虚增 OK 遮蔽未来的原生覆盖回归(本 PR 下仍 51/51 精确不变)。
- `docs/llvm/tier1-hybrid.md` 状态行:default-on + opt-out 语义。

## 用户可见行为变化

`lk compile` 遇到含不可 lower 函数的程序:此前整程序回退 Tier 0 VM bundle(警告),现在合格函数走嵌入 VM 桥、其余保持原生(`note: N function(s) run on the embedded VM (Tier 1 hybrid)`)。不合格形状仍回退 Tier 0,回退语义与警告不变。

## 验证

- coverage 51/51 精确不变 · fuzz 40(真实默认)· hybrid e2e 5/5(含 sanitized)· 手写差分 12/12 · examples 51 · workspace `--all-features` + `RUSTFLAGS=-D warnings` 0 失败 · clippy `--all-targets` 0
- **perf 零影响硬证据**:bench workload 翻默认前后 `lk compile llvm` 产出的 `.ll` 逐字节一致(全原生程序不经过桥,lowering 决策不变)
- 紧急兜底:单 commit revert,或用户侧 `LK_AOT_HYBRID=0`

合并后 correctness 会随 push 再跑一轮(路径含 aot/**),建议照常盯 2-3 晚 cron。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AOT 混合模式现在默认开启；未设置环境变量时会自动生效。
  * 可通过将环境变量设为 `0` 来关闭混合模式，便于按需切换。

* **Bug Fixes**
  * 更新了相关校验逻辑，确保默认行为与实际执行一致。
  * 覆盖率统计现在固定按纯原生路径执行，避免混合模式影响结果。

* **Documentation**
  * 同步更新了混合模式说明与使用方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->