### PR TITLE
fix: main 修红(clippy 0.1.97)+ 补齐 Cranelift Phase 1/2a/2b

### DIFF
--- a/aot/codegen/src/clif.rs
+++ b/aot/codegen/src/clif.rs
@@ -128,6 +128,12 @@ pub fn compile_module(mir: &MirModule, isa: std::sync::Arc<dyn TargetIsa>) -> Re
     let builder = ObjectBuilder::new(isa, name, cranelift_module::default_libcall_names())
         .map_err(|e| ClifError::Module(e.to_string()))?;
     let mut module = ObjectModule::new(builder);
+    // Pointer-sized ABI shapes (handles/strings) and the `LkDyn {i64,i64}` carrier
+    // are all 64-bit in the shared `lkrt` ABI, so pointers lower to `I64`. Reject
+    // a non-64-bit target rather than silently emit wrong-width values.
+    if module.isa().pointer_type() != types::I64 {
+        return Err(ClifError::Unsupported("non-64-bit target (the lkrt ABI is 64-bit)"));
+    }
     let cc = module.isa().default_call_conv();
 
     // Declare every function up front so calls can resolve intra-module targets.
@@ -543,7 +549,7 @@ mod tests {
     /// (`compile_module` verifies every function and emits a native object).
     /// Success proves the lowering produced valid, codegen-able CLIF — the
     /// typed-builder correctness win the string-IR path lacked.
-    fn compile_ok(funcs: Vec<MirFunction>) -> Result<Vec<u8>, String> {
+    fn compile_ok(funcs: Vec<MirFunction>) -> Result<Vec<u8>, ClifError> {
         let mir = MirModule {
             abi_version: 0,
             globals: vec![],
@@ -552,7 +558,7 @@ mod tests {
             entry: funcs[0].id,
             functions: funcs,
         };
-        compile_module(&mir, host_isa()).map_err(|e| format!("{e:?}"))
+        compile_module(&mir, host_isa())
     }
 
     fn vid(n: u32) -> ValueId {
@@ -760,7 +766,8 @@ mod tests {
         compile_module(&mir, host_isa()).expect("string const + globals must compile");
     }
 
-    // A shape still outside the slice (a `Dyn` param) rejects cleanly.
+    // A shape still outside the slice (a `Dyn` param) rejects at the capability
+    // boundary — specifically `Unsupported`, not an unrelated module/emit error.
     #[test]
     fn rejects_unsupported_shape() {
         let func = MirFunction {
@@ -775,6 +782,6 @@ mod tests {
             entry: BlockId(0),
             ret: Ty::Dyn,
         };
-        assert!(compile_ok(vec![func]).is_err());
+        assert!(matches!(compile_ok(vec![func]), Err(ClifError::Unsupported(_))));
     }
 }

--- a/aot/codegen/src/clif.rs
+++ b/aot/codegen/src/clif.rs
@@ -15,16 +15,177 @@
 use std::collections::HashMap;
 
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
-use cranelift_codegen::ir::{AbiParam, BlockArg, Function, InstBuilder, Signature, Value, types};
-use cranelift_codegen::isa::CallConv;
+use cranelift_codegen::ir::{AbiParam, BlockArg, Function, InstBuilder, MemFlagsData, Signature, Value, types};
+use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use lk_aot_mir::{CmpOp, Const, FloatBinOp, Inst, IntBinOp, MirFunction, Term, Ty};
+use cranelift_module::{DataDescription, DataId, FuncId as ClifFuncId, Linkage, Module, ModuleError};
+use cranelift_object::{ObjectBuilder, ObjectModule};
+use lk_aot_mir::{CmpOp, Const, FloatBinOp, FuncId, Inst, IntBinOp, MirFunction, MirModule, Term, Ty};
 
 /// Why a MIR shape is not (yet) lowerable through the Cranelift path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClifError {
     /// An instruction/type outside the current phase's slice.
     Unsupported(&'static str),
+    /// A `cranelift-module` failure (declaration/definition/emit).
+    Module(String),
+}
+
+impl From<ModuleError> for ClifError {
+    fn from(err: ModuleError) -> Self {
+        ClifError::Module(err.to_string())
+    }
+}
+
+/// The guarded integer/float divide/mod helpers (`lkrt`), never raw `sdiv`/`srem`
+/// — matching the VM's divide-by-zero abort. Declared as imports and resolved by
+/// linking the `lkrt` staticlib.
+struct Helpers {
+    i64_div: ClifFuncId,
+    i64_mod: ClifFuncId,
+    f64_div: ClifFuncId,
+    f64_mod: ClifFuncId,
+}
+
+impl Helpers {
+    fn declare(module: &mut dyn Module) -> Result<Self, ClifError> {
+        let cc = module.isa().default_call_conv();
+        let ii = |m: &mut dyn Module, name: &str, ty: types::Type| -> Result<ClifFuncId, ClifError> {
+            let mut sig = Signature::new(cc);
+            sig.params.push(AbiParam::new(ty));
+            sig.params.push(AbiParam::new(ty));
+            sig.returns.push(AbiParam::new(ty));
+            Ok(m.declare_function(name, Linkage::Import, &sig)?)
+        };
+        Ok(Helpers {
+            i64_div: ii(module, "lkrt_i64_div_checked", types::I64)?,
+            i64_mod: ii(module, "lkrt_i64_mod_checked", types::I64)?,
+            f64_div: ii(module, "lkrt_f64_div_checked", types::F64)?,
+            f64_mod: ii(module, "lkrt_f64_mod_checked", types::F64)?,
+        })
+    }
+}
+
+/// Per-module lowering context threaded into the builder: the module (for
+/// importing callees) plus the intra-module function, helper, and on-demand ABI
+/// symbol tables.
+struct ModuleCtx<'a> {
+    module: &'a mut dyn Module,
+    fn_ids: &'a HashMap<FuncId, ClifFuncId>,
+    helpers: &'a Helpers,
+    /// Declared ABI runtime symbols, cached by C symbol name (declared lazily so
+    /// a program that never calls one does not force its — possibly `DynVal` —
+    /// signature to lower).
+    abi_ids: &'a mut HashMap<&'static str, ClifFuncId>,
+    /// Interned string-constant data symbols (`lk_str_{i}`), by [`GlobalId`] index.
+    str_data: &'a HashMap<u32, DataId>,
+    /// Mutable module-global data symbols (`lk_gvar_{i}`) + their MIR type.
+    gvar_data: &'a HashMap<u32, (DataId, Ty)>,
+}
+
+impl ModuleCtx<'_> {
+    /// Declare (once) an ABI runtime function by its schema entry and return its
+    /// Cranelift id. Rejects `DynVal`-carrying signatures (the `{i64,i64}`
+    /// carrier is Phase 2b).
+    fn abi_func(&mut self, abi: &lk_aot_abi::AbiFn) -> Result<ClifFuncId, ClifError> {
+        if let Some(id) = self.abi_ids.get(abi.symbol) {
+            return Ok(*id);
+        }
+        let cc = self.module.isa().default_call_conv();
+        let mut sig = Signature::new(cc);
+        for p in abi.params {
+            sig.params.push(AbiParam::new(abi_ty_to_clif(*p)?));
+        }
+        if !matches!(abi.result, lk_aot_abi::AbiType::Nil) {
+            sig.returns.push(AbiParam::new(abi_ty_to_clif(abi.result)?));
+        }
+        let id = self.module.declare_function(abi.symbol, Linkage::Import, &sig)?;
+        self.abi_ids.insert(abi.symbol, id);
+        Ok(id)
+    }
+}
+
+/// The Cranelift type of an ABI parameter/return. Pointers are pointer-sized;
+/// the `{i64,i64}` `DynVal` carrier is Phase 2b.
+fn abi_ty_to_clif(ty: lk_aot_abi::AbiType) -> Result<types::Type, ClifError> {
+    use lk_aot_abi::AbiType;
+    Ok(match ty {
+        AbiType::I64 => types::I64,
+        AbiType::F64 => types::F64,
+        AbiType::Ptr | AbiType::StrPtr => types::I64,
+        AbiType::Nil => return Err(ClifError::Unsupported("nil ABI operand")),
+        AbiType::DynVal => return Err(ClifError::Unsupported("DynVal {i64,i64} ABI carrier")),
+    })
+}
+
+/// Compile a whole [`MirModule`]'s non-entry functions to a native object for
+/// `isa`. Returns the object bytes (to be linked against `lkrt`). The
+/// entry/`main` shape and the ABI-runtime/string/container instructions arrive
+/// in later phases; a function using anything outside the slice returns
+/// [`ClifError::Unsupported`].
+pub fn compile_module(mir: &MirModule, isa: std::sync::Arc<dyn TargetIsa>) -> Result<Vec<u8>, ClifError> {
+    let name = "lk_aot";
+    let builder = ObjectBuilder::new(isa, name, cranelift_module::default_libcall_names())
+        .map_err(|e| ClifError::Module(e.to_string()))?;
+    let mut module = ObjectModule::new(builder);
+    let cc = module.isa().default_call_conv();
+
+    // Declare every function up front so calls can resolve intra-module targets.
+    let mut fn_ids = HashMap::new();
+    for func in &mir.functions {
+        let sig = signature_of(func, cc)?;
+        let sym = format!("lk_fn_{}", func.id.0);
+        let id = module.declare_function(&sym, Linkage::Local, &sig)?;
+        fn_ids.insert(func.id, id);
+    }
+    let helpers = Helpers::declare(&mut module)?;
+
+    // Interned string constants → read-only, NUL-terminated data symbols.
+    let mut str_data: HashMap<u32, DataId> = HashMap::new();
+    for (i, s) in mir.globals.iter().enumerate() {
+        let id = module.declare_data(&format!("lk_str_{i}"), Linkage::Local, false, false)?;
+        let mut bytes = s.clone().into_bytes();
+        bytes.push(0);
+        let mut desc = DataDescription::new();
+        desc.define(bytes.into_boxed_slice());
+        module.define_data(id, &desc)?;
+        str_data.insert(i as u32, id);
+    }
+    // Mutable module globals → writable, zero-initialized data symbols.
+    let mut gvar_data: HashMap<u32, (DataId, Ty)> = HashMap::new();
+    for (i, (_, ty)) in mir.mutable_globals.iter().enumerate() {
+        let size = ty_to_clif(*ty)?.bytes() as usize;
+        let id = module.declare_data(&format!("lk_gvar_{i}"), Linkage::Local, true, false)?;
+        let mut desc = DataDescription::new();
+        desc.define_zeroinit(size);
+        module.define_data(id, &desc)?;
+        gvar_data.insert(i as u32, (id, *ty));
+    }
+
+    // ABI runtime symbols are declared lazily but must dedup across functions.
+    let mut abi_ids: HashMap<&'static str, ClifFuncId> = HashMap::new();
+
+    for func in &mir.functions {
+        let mut ctx = module.make_context();
+        ctx.func.signature = signature_of(func, cc)?;
+        let mut fb_ctx = FunctionBuilderContext::new();
+        {
+            let mut mctx = ModuleCtx {
+                module: &mut module,
+                fn_ids: &fn_ids,
+                helpers: &helpers,
+                abi_ids: &mut abi_ids,
+                str_data: &str_data,
+                gvar_data: &gvar_data,
+            };
+            build_function(func, &mut ctx.func, &mut fb_ctx, &mut mctx)?;
+        }
+        module.define_function(fn_ids[&func.id], &mut ctx)?;
+        module.clear_context(&mut ctx);
+    }
+
+    let product = module.finish();
+    product.emit().map_err(|e| ClifError::Module(e.to_string()))
 }
 
 /// The Cranelift value type carrying a MIR [`Ty`] at the ABI. Scalars are
@@ -71,10 +232,11 @@ pub fn signature_of(func: &MirFunction, call_conv: CallConv) -> Result<Signature
 
 /// Lower a non-entry MIR function body into `clif_func` (whose signature must
 /// already match [`signature_of`]).
-pub fn build_function(
+fn build_function(
     func: &MirFunction,
     clif_func: &mut Function,
     fb_ctx: &mut FunctionBuilderContext,
+    mctx: &mut ModuleCtx,
 ) -> Result<(), ClifError> {
     let mut builder = FunctionBuilder::new(clif_func, fb_ctx);
     let mut lower = Lower {
@@ -109,7 +271,7 @@ pub fn build_function(
         let cb = lower.blocks[&block.id];
         builder.switch_to_block(cb);
         for inst in &block.insts {
-            lower.inst(&mut builder, inst)?;
+            lower.inst(&mut builder, mctx, inst)?;
         }
         lower.term(&mut builder, &block.term)?;
     }
@@ -132,23 +294,78 @@ impl Lower {
             .ok_or(ClifError::Unsupported("value used before def"))
     }
 
+    /// Resolve a list of value operands (call arguments).
+    fn args_v(&self, ids: &[lk_aot_mir::ValueId]) -> Result<Vec<Value>, ClifError> {
+        ids.iter().map(|id| self.v(*id)).collect()
+    }
+
     /// Block-call arguments (branch-passed values become the target block's params).
     fn block_args(&self, ids: &[lk_aot_mir::ValueId]) -> Result<Vec<BlockArg>, ClifError> {
         ids.iter().map(|id| Ok(BlockArg::Value(self.v(*id)?))).collect()
     }
 
-    fn inst(&mut self, b: &mut FunctionBuilder, inst: &Inst) -> Result<(), ClifError> {
+    /// Import `callee` into the current function and emit a call, binding the
+    /// single return value (if any) to `dst`.
+    fn call(
+        &mut self,
+        b: &mut FunctionBuilder,
+        mctx: &mut ModuleCtx,
+        callee: ClifFuncId,
+        dst: Option<lk_aot_mir::ValueId>,
+        args: &[Value],
+    ) -> Result<(), ClifError> {
+        let func_ref = mctx.module.declare_func_in_func(callee, b.func);
+        let call = b.ins().call(func_ref, args);
+        if let Some(dst) = dst {
+            let results = b.inst_results(call);
+            let v = *results
+                .first()
+                .ok_or(ClifError::Unsupported("call has no result for dst"))?;
+            self.values.insert(dst, v);
+        }
+        Ok(())
+    }
+
+    fn inst(&mut self, b: &mut FunctionBuilder, mctx: &mut ModuleCtx, inst: &Inst) -> Result<(), ClifError> {
         match inst {
             Inst::Const { dst, value } => {
                 let v = match value {
                     Const::I64(x) => b.ins().iconst(types::I64, *x),
                     Const::F64(x) => b.ins().f64const(*x),
                     Const::Bool(x) => b.ins().iconst(types::I8, i64::from(*x)),
-                    Const::Str(_) | Const::FnAddr(_) | Const::Nil => {
-                        return Err(ClifError::Unsupported("str/fnaddr/nil const"));
+                    Const::Str(g) => {
+                        let data_id = *mctx
+                            .str_data
+                            .get(&g.0)
+                            .ok_or(ClifError::Unsupported("undeclared string const"))?;
+                        let gv = mctx.module.declare_data_in_func(data_id, b.func);
+                        b.ins().global_value(types::I64, gv)
+                    }
+                    Const::FnAddr(_) | Const::Nil => {
+                        return Err(ClifError::Unsupported("fnaddr/nil const"));
                     }
                 };
                 self.values.insert(*dst, v);
+            }
+            Inst::GlobalGet { dst, gvar } => {
+                let (data_id, ty) = *mctx
+                    .gvar_data
+                    .get(gvar)
+                    .ok_or(ClifError::Unsupported("undeclared global"))?;
+                let gv = mctx.module.declare_data_in_func(data_id, b.func);
+                let addr = b.ins().global_value(types::I64, gv);
+                let v = b.ins().load(ty_to_clif(ty)?, MemFlagsData::trusted(), addr, 0);
+                self.values.insert(*dst, v);
+            }
+            Inst::GlobalSet { gvar, src } => {
+                let s = self.v(*src)?;
+                let (data_id, _) = *mctx
+                    .gvar_data
+                    .get(gvar)
+                    .ok_or(ClifError::Unsupported("undeclared global"))?;
+                let gv = mctx.module.declare_data_in_func(data_id, b.func);
+                let addr = b.ins().global_value(types::I64, gv);
+                b.ins().store(MemFlagsData::trusted(), s, addr, 0);
             }
             Inst::IntBin { dst, op, lhs, rhs } => {
                 let (l, r) = (self.v(*lhs)?, self.v(*rhs)?);
@@ -167,8 +384,9 @@ impl Lower {
                         let c = b.ins().icmp(IntCC::SignedGreaterThan, l, r);
                         b.ins().select(c, l, r)
                     }
-                    // Guarded divide/mod call the lkrt helpers (Phase 2, needs symbols).
-                    IntBinOp::Div | IntBinOp::Mod => return Err(ClifError::Unsupported("guarded int div/mod")),
+                    // Guarded divide/mod call the lkrt helpers (never raw sdiv/srem).
+                    IntBinOp::Div => return self.call(b, mctx, mctx.helpers.i64_div, Some(*dst), &[l, r]),
+                    IntBinOp::Mod => return self.call(b, mctx, mctx.helpers.i64_mod, Some(*dst), &[l, r]),
                 };
                 self.values.insert(*dst, v);
             }
@@ -178,9 +396,24 @@ impl Lower {
                     FloatBinOp::Add => b.ins().fadd(l, r),
                     FloatBinOp::Sub => b.ins().fsub(l, r),
                     FloatBinOp::Mul => b.ins().fmul(l, r),
-                    FloatBinOp::Div | FloatBinOp::Mod => return Err(ClifError::Unsupported("guarded float div/mod")),
+                    FloatBinOp::Div => return self.call(b, mctx, mctx.helpers.f64_div, Some(*dst), &[l, r]),
+                    FloatBinOp::Mod => return self.call(b, mctx, mctx.helpers.f64_mod, Some(*dst), &[l, r]),
                 };
                 self.values.insert(*dst, v);
+            }
+            Inst::CallFn { dst, func, args } => {
+                let a = self.args_v(args)?;
+                let callee = *mctx
+                    .fn_ids
+                    .get(func)
+                    .ok_or(ClifError::Unsupported("call to undeclared function"))?;
+                return self.call(b, mctx, callee, *dst, &a);
+            }
+            Inst::Call { dst, callee, args } => {
+                let abi = callee.resolve().ok_or(ClifError::Unsupported("unknown ABI function"))?;
+                let a = self.args_v(args)?;
+                let clif_id = mctx.abi_func(abi)?;
+                return self.call(b, mctx, clif_id, *dst, &a);
             }
             Inst::Cmp {
                 dst,
@@ -294,29 +527,32 @@ fn float_cc(op: CmpOp) -> FloatCC {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cranelift_codegen::Context;
     use cranelift_codegen::settings::{self, Configurable};
-    use lk_aot_mir::{Block as MirBlock, BlockId, FuncId, ValueId};
+    use lk_aot_mir::{Block as MirBlock, BlockId, ValueId};
 
-    /// Lower `func` and drive it through the full Cranelift pipeline
-    /// (`Context::compile` runs the verifier and emits machine code). Success
-    /// proves the lowering produced valid, codegen-able CLIF — the typed-builder
-    /// correctness win the string-IR path lacked.
-    fn compile_ok(func: &MirFunction) -> Result<(), String> {
+    fn host_isa() -> std::sync::Arc<dyn TargetIsa> {
         let mut flags = settings::builder();
         flags.set("opt_level", "speed").unwrap();
-        let isa = cranelift_native::builder()
+        cranelift_native::builder()
             .unwrap()
             .finish(settings::Flags::new(flags))
-            .map_err(|e| e.to_string())?;
-        let sig = signature_of(func, isa.default_call_conv()).map_err(|e| format!("{e:?}"))?;
-        let mut ctx = Context::new();
-        ctx.func.signature = sig;
-        let mut fb_ctx = FunctionBuilderContext::new();
-        build_function(func, &mut ctx.func, &mut fb_ctx).map_err(|e| format!("{e:?}"))?;
-        ctx.compile(&*isa, &mut Default::default())
-            .map(|_| ())
-            .map_err(|e| format!("{e:?}"))
+            .unwrap()
+    }
+
+    /// Lower `funcs` as a module and drive the full Cranelift pipeline
+    /// (`compile_module` verifies every function and emits a native object).
+    /// Success proves the lowering produced valid, codegen-able CLIF — the
+    /// typed-builder correctness win the string-IR path lacked.
+    fn compile_ok(funcs: Vec<MirFunction>) -> Result<Vec<u8>, String> {
+        let mir = MirModule {
+            abi_version: 0,
+            globals: vec![],
+            mutable_globals: vec![],
+            vm_functions: vec![],
+            entry: funcs[0].id,
+            functions: funcs,
+        };
+        compile_module(&mir, host_isa()).map_err(|e| format!("{e:?}"))
     }
 
     fn vid(n: u32) -> ValueId {
@@ -356,7 +592,7 @@ mod tests {
             entry: BlockId(0),
             ret: Ty::I64,
         };
-        compile_ok(&func).expect("scalar arithmetic must compile");
+        compile_ok(vec![func]).expect("scalar arithmetic must compile");
     }
 
     // fn(x: i64) -> i64 { if x < 10 { return x } else { return 10 } } — block-param CFG.
@@ -399,30 +635,146 @@ mod tests {
             entry: BlockId(0),
             ret: Ty::I64,
         };
-        compile_ok(&func).expect("block-param control flow must compile");
+        compile_ok(vec![func]).expect("block-param control flow must compile");
     }
 
-    // A deliberately-out-of-slice shape rejects cleanly instead of miscompiling.
+    // Guarded div/mod (lkrt helpers) and a cross-function call — Phase 1.
     #[test]
-    fn rejects_unsupported_shape() {
-        let block = MirBlock {
-            id: BlockId(0),
-            params: vec![],
-            insts: vec![Inst::IntBin {
-                dst: vid(2),
-                op: IntBinOp::Div,
-                lhs: vid(0),
-                rhs: vid(1),
-            }],
-            term: Term::Ret(Some(vid(2))),
-        };
-        let func = MirFunction {
-            id: FuncId(0),
+    fn lowers_guarded_div_and_direct_call() {
+        // fn callee(a, b) -> i64 { return a / b }  (guarded lkrt div)
+        let callee = MirFunction {
+            id: FuncId(1),
             params: vec![(vid(0), Ty::I64), (vid(1), Ty::I64)],
-            blocks: vec![block],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![Inst::IntBin {
+                    dst: vid(2),
+                    op: IntBinOp::Div,
+                    lhs: vid(0),
+                    rhs: vid(1),
+                }],
+                term: Term::Ret(Some(vid(2))),
+            }],
             entry: BlockId(0),
             ret: Ty::I64,
         };
-        assert!(compile_ok(&func).is_err());
+        // fn caller(x) -> i64 { return callee(x, 3) }
+        let caller = MirFunction {
+            id: FuncId(0),
+            params: vec![(vid(0), Ty::I64)],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![
+                    Inst::Const {
+                        dst: vid(1),
+                        value: Const::I64(3),
+                    },
+                    Inst::CallFn {
+                        dst: Some(vid(2)),
+                        func: FuncId(1),
+                        args: vec![vid(0), vid(1)],
+                    },
+                ],
+                term: Term::Ret(Some(vid(2))),
+            }],
+            entry: BlockId(0),
+            ret: Ty::I64,
+        };
+        compile_ok(vec![caller, callee]).expect("div + direct call must compile");
+    }
+
+    // A scalar ABI runtime call (`lkrt.abi_version() -> i64`) — Phase 2. The
+    // symbol is declared as an import and resolved by linking `lkrt`.
+    #[test]
+    fn lowers_scalar_abi_call() {
+        use lk_aot_mir::AbiRef;
+        let func = MirFunction {
+            id: FuncId(0),
+            params: vec![],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![Inst::Call {
+                    dst: Some(vid(0)),
+                    callee: AbiRef::new("lkrt", "abi_version"),
+                    args: vec![],
+                }],
+                term: Term::Ret(Some(vid(0))),
+            }],
+            entry: BlockId(0),
+            ret: Ty::I64,
+        };
+        compile_ok(vec![func]).expect("scalar ABI call must compile");
+    }
+
+    // Const::Str (data symbol) + mutable-global load/store — Phase 2b.
+    #[test]
+    fn lowers_string_const_and_globals() {
+        use lk_aot_mir::GlobalId;
+        // fn() -> i64 { gvar0 = 42; return gvar0 }
+        let set_get = MirFunction {
+            id: FuncId(0),
+            params: vec![],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![
+                    Inst::Const {
+                        dst: vid(0),
+                        value: Const::I64(42),
+                    },
+                    Inst::GlobalSet { gvar: 0, src: vid(0) },
+                    Inst::GlobalGet { dst: vid(1), gvar: 0 },
+                ],
+                term: Term::Ret(Some(vid(1))),
+            }],
+            entry: BlockId(0),
+            ret: Ty::I64,
+        };
+        // fn() -> str { return "hi" }
+        let get_str = MirFunction {
+            id: FuncId(1),
+            params: vec![],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![Inst::Const {
+                    dst: vid(0),
+                    value: Const::Str(GlobalId(0)),
+                }],
+                term: Term::Ret(Some(vid(0))),
+            }],
+            entry: BlockId(0),
+            ret: Ty::Str,
+        };
+        let mir = MirModule {
+            abi_version: 0,
+            globals: vec!["hi".to_string()],
+            mutable_globals: vec![("g".to_string(), Ty::I64)],
+            vm_functions: vec![],
+            entry: FuncId(0),
+            functions: vec![set_get, get_str],
+        };
+        compile_module(&mir, host_isa()).expect("string const + globals must compile");
+    }
+
+    // A shape still outside the slice (a `Dyn` param) rejects cleanly.
+    #[test]
+    fn rejects_unsupported_shape() {
+        let func = MirFunction {
+            id: FuncId(0),
+            params: vec![(vid(0), Ty::Dyn)],
+            blocks: vec![MirBlock {
+                id: BlockId(0),
+                params: vec![],
+                insts: vec![],
+                term: Term::Ret(Some(vid(0))),
+            }],
+            entry: BlockId(0),
+            ret: Ty::Dyn,
+        };
+        assert!(compile_ok(vec![func]).is_err());
     }
 }

--- a/core/src/ast/parser/literals.rs
+++ b/core/src/ast/parser/literals.rs
@@ -115,7 +115,7 @@ impl<'a> Parser<'a> {
                 Ok(expr)
             }
             _ => {
-                let msg = format!("Invalid field name: {:?}", &self.tokens[self.pos]);
+                let msg = format!("Invalid field name: {:?}", self.tokens[self.pos]);
                 Err(anyhow!(self.err(&msg)))
             }
         }

--- a/values/src/numeric.rs
+++ b/values/src/numeric.rs
@@ -27,11 +27,8 @@ impl NumericHierarchy {
                     if matches!(item, Type::Nil) {
                         continue;
                     }
-                    if let Some(class) = NumericHierarchy::classify(item) {
-                        result = Some(result.map(|r| r.max(class)).unwrap_or(class));
-                    } else {
-                        return None;
-                    }
+                    let class = NumericHierarchy::classify(item)?;
+                    result = Some(result.map(|r| r.max(class)).unwrap_or(class));
                 }
                 result
             }


### PR DESCRIPTION
PR #25 squash 合并时远端分支只到 Cranelift Phase 0(本地 Phase 1/2a 未推),叠加 CI 的 stable clippy 升到 0.1.97 报新 lint → 合并后 main 的 Rust Check 红。

本 PR 从 main 出发修复:
- **clippy 0.1.97 新 lint**:`values/numeric.rs`(if-let-else-return-None → `?`)· `parser/literals.rs`(`format!` 冗余 `&`)
- **补齐 `aot/codegen/src/clif.rs` 到 Phase 0-2b**:guarded div/mod · 直接调用 · ObjectModule 产 .o · 标量 ABI 调用 · Const::Str 数据符号 · 可变全局 load/store

验证:`cargo test --workspace --all-features` **1555/0** · clippy 1.97 `--all-targets --all-features -D warnings` 0 · fmt 0。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Native compilation now supports string constants, mutable globals, cross-function calls, runtime calls, and guarded integer or floating-point division and remainder operations.
  - Added support for compiling modules containing multiple functions and shared data.

- **Bug Fixes**
  - Improved invalid field-name error formatting.
  - Union numeric classification now correctly stops when a member cannot be classified.
  - Expanded compilation coverage for arithmetic, control flow, globals, strings, and function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->