### PR TITLE
fix: codegen miscompile, red CI gates, and type-checker/resolver

### DIFF
--- a/aot/codegen/src/clif.rs
+++ b/aot/codegen/src/clif.rs
@@ -157,20 +157,13 @@ impl ModuleCtx<'_> {
         for t in returns {
             sig.returns.push(AbiParam::new(*t));
         }
-        if let Some(id) = self.abi_ids.get(symbol) {
-            // A symbol has exactly one signature in a module, so a second
-            // request with a different one is a codegen bug — and silently
-            // returning the first declaration is how it became a malformed call
-            // that only the Cranelift verifier noticed, reported against a
-            // machine call site with no way back to the symbol.
-            let declared = &self.module.declarations().get_function_decl(*id).signature;
-            if declared != &sig {
-                return Err(ClifError::Module(format!(
-                    "{symbol} already declared as {declared:?}, now requested as {sig:?}"
-                )));
-            }
-            return Ok(*id);
-        }
+        // Re-declaring is how a signature conflict is detected: `declare_function`
+        // returns the existing id for a matching signature and
+        // `ModuleError::IncompatibleSignature` otherwise. Silently returning the
+        // cached id — this cached by symbol name alone — is how a second request
+        // with a different signature became a malformed call that only the
+        // Cranelift verifier noticed, reported against a machine call site with no
+        // way back to the symbol.
         let id = self.module.declare_function(symbol, Linkage::Import, &sig)?;
         self.abi_ids.insert(symbol, id);
         Ok(id)

--- a/aot/codegen/src/clif.rs
+++ b/aot/codegen/src/clif.rs
@@ -51,7 +51,14 @@ pub enum ClifError {
 
 impl From<ModuleError> for ClifError {
     fn from(err: ModuleError) -> Self {
-        ClifError::Module(err.to_string())
+        // `Display` on a `ModuleError::Compilation(Verifier(..))` collapses the
+        // whole report to the words "Verifier errors", which tells a CI failure
+        // reader nothing about which instruction is malformed. `Debug` carries
+        // the per-instruction list.
+        match &err {
+            ModuleError::Compilation(inner) => ClifError::Module(format!("{err}: {inner:?}")),
+            _ => ClifError::Module(err.to_string()),
+        }
     }
 }
 
@@ -142,9 +149,6 @@ impl ModuleCtx<'_> {
         params: &[types::Type],
         returns: &[types::Type],
     ) -> Result<ClifFuncId, ClifError> {
-        if let Some(id) = self.abi_ids.get(symbol) {
-            return Ok(*id);
-        }
         let cc = self.module.isa().default_call_conv();
         let mut sig = Signature::new(cc);
         for t in params {
@@ -152,6 +156,20 @@ impl ModuleCtx<'_> {
         }
         for t in returns {
             sig.returns.push(AbiParam::new(*t));
+        }
+        if let Some(id) = self.abi_ids.get(symbol) {
+            // A symbol has exactly one signature in a module, so a second
+            // request with a different one is a codegen bug — and silently
+            // returning the first declaration is how it became a malformed call
+            // that only the Cranelift verifier noticed, reported against a
+            // machine call site with no way back to the symbol.
+            let declared = &self.module.declarations().get_function_decl(*id).signature;
+            if declared != &sig {
+                return Err(ClifError::Module(format!(
+                    "{symbol} already declared as {declared:?}, now requested as {sig:?}"
+                )));
+            }
+            return Ok(*id);
         }
         let id = self.module.declare_function(symbol, Linkage::Import, &sig)?;
         self.abi_ids.insert(symbol, id);
@@ -599,6 +617,21 @@ impl Lower {
         args: &[Value],
     ) -> Result<(), ClifError> {
         let func_ref = mctx.module.declare_func_in_func(callee, b.func);
+        // Checked here rather than left to the Cranelift verifier: the verifier
+        // reports the *machine* call ("got 2, expected 1") with no way back to
+        // the callee, which is unreadable in a CI log. A mismatch means the
+        // machine-value expansion at the call site disagrees with the signature
+        // the callee was declared with (a `DynVal` is a register pair).
+        let expected = b.func.dfg.signatures[b.func.dfg.ext_funcs[func_ref].signature]
+            .params
+            .len();
+        if expected != args.len() {
+            let name = b.func.dfg.ext_funcs[func_ref].name.display(None).to_string();
+            return Err(ClifError::Module(format!(
+                "call to {name} passes {} machine argument(s), declared with {expected}",
+                args.len()
+            )));
+        }
         let call = b.ins().call(func_ref, args);
         if let Some(dst) = dst {
             let results = b.inst_results(call);
@@ -752,6 +785,22 @@ impl Lower {
             Inst::Call { dst, callee, args } => {
                 let abi = callee.resolve().ok_or(ClifError::Unsupported("unknown ABI function"))?;
                 let a = self.args_v(args)?;
+                // Named here, where the callee is still known: a mismatch means a
+                // MIR argument expanded to a different number of machine values
+                // than the schema declares (a `DynVal` is a register pair), and
+                // the Cranelift verifier can only report the machine call site.
+                let mut declared = 0usize;
+                for p in abi.params {
+                    declared += abi_ty_clif_parts(*p)?.len();
+                }
+                if declared != a.len() {
+                    return Err(ClifError::Module(format!(
+                        "{}.{} takes {declared} machine argument(s) per the ABI schema, call site passes {}",
+                        abi.module,
+                        abi.name,
+                        a.len()
+                    )));
+                }
                 let dst_pair = matches!(abi.result, lk_aot_abi::AbiType::DynVal);
                 let clif_id = mctx.abi_func(abi)?;
                 return self.call_raw(b, mctx, clif_id, *dst, dst_pair, &a);

--- a/aot/lower/src/lib.rs
+++ b/aot/lower/src/lib.rs
@@ -170,105 +170,113 @@ pub fn lower_bundled(
     // (bounded — the scalar lattice converges quickly). Transient failures are
     // tolerated here (a function may not lower until the types it depends on have
     // converged); the final pass below is authoritative and propagates errors.
-    let mut passes = 0usize;
-    loop {
-        let snapshot = (
-            sig.param_obs.clone(),
-            sig.ret_types.clone(),
-            sig.specializations.len(),
-            sig.ret_closures.clone(),
-            sig.dyn_loop_phis.len(),
-            sig.dyn_empty_lists.len(),
-            sig.dyn_rets.len(),
-            sig.global_tys.clone(),
-            sig.spawned_isolate.len(),
-            sig.force_dyn_globals.len(),
-        );
-        // Call-site facts are re-derived every pass: an argument register
-        // that resolves to a closure ref only once a summary lands (e.g. a
-        // summarized callee's result) must not leave a stale plain-call mark
-        // from the pass before the summary existed. The final pass inherits
-        // the converged flags of the last fixpoint pass.
-        sig.specialized.iter_mut().for_each(|flag| *flag = false);
-        sig.plain_called.iter_mut().for_each(|flag| *flag = false);
-        sig.conflict = false;
-        for fi in 0..funcs.len() {
-            if !reachable[fi] {
-                continue;
-            }
-            // Originals whose call sites all pass lambdas are fully replaced
-            // by their clones (their bodies would reject without erasure).
-            if sig.specialized.get(fi).copied().unwrap_or(false) {
-                continue;
-            }
-            // Summarized closure-returning functions are consumed at call
-            // sites; their pure bodies are never emitted.
-            if sig.ret_closures.get(fi).is_some_and(Option::is_some) {
-                continue;
-            }
-            let is_entry = fi as u32 == module.entry;
-            let mut scratch = Vec::new();
-            let lowered = lower_function(
-                &funcs[fi],
-                &funcs,
-                fi as u32,
-                module.entry,
-                is_entry,
-                &mut scratch,
-                &module.globals,
-                &mut sig,
+    // A closure so the hybrid rerun below can re-converge: marking a function
+    // VM-executed changes the type lattice (its callers now see the bridge's
+    // `Dyn` result, which widens their own params and returns), and emitting
+    // against the pre-marking signatures is how a caller ended up calling
+    // `str.from_i64` with a register pair.
+    let refine_signatures = |sig: &mut SigInfer, funcs: &mut Vec<FunctionData>, reachable: &mut Vec<bool>| {
+        let mut passes = 0usize;
+        loop {
+            let snapshot = (
+                sig.param_obs.clone(),
+                sig.ret_types.clone(),
+                sig.specializations.len(),
+                sig.ret_closures.clone(),
+                sig.dyn_loop_phis.len(),
+                sig.dyn_empty_lists.len(),
+                sig.dyn_rets.len(),
+                sig.global_tys.clone(),
+                sig.spawned_isolate.len(),
+                sig.force_dyn_globals.len(),
             );
-            match lowered {
-                Ok(mf) if !is_entry => {
-                    sig.ret_types[fi] = mf.ret;
-                    sig.ret_known[fi] = true;
+            // Call-site facts are re-derived every pass: an argument register
+            // that resolves to a closure ref only once a summary lands (e.g. a
+            // summarized callee's result) must not leave a stale plain-call mark
+            // from the pass before the summary existed. The final pass inherits
+            // the converged flags of the last fixpoint pass.
+            sig.specialized.iter_mut().for_each(|flag| *flag = false);
+            sig.plain_called.iter_mut().for_each(|flag| *flag = false);
+            sig.conflict = false;
+            for fi in 0..funcs.len() {
+                if !reachable[fi] {
+                    continue;
                 }
-                // A retriable loop-phi discovery: record it (the snapshot
-                // includes the set's size, so the fixpoint runs again with
-                // the phi pre-typed Dyn).
-                Err(Unsupported::DynLoopPhi { block, slot }) => {
-                    sig.dyn_loop_phis.insert((fi as u32, block, slot));
+                // Originals whose call sites all pass lambdas are fully replaced
+                // by their clones (their bodies would reject without erasure).
+                if sig.specialized.get(fi).copied().unwrap_or(false) {
+                    continue;
                 }
-                Err(Unsupported::EmptyListGuessWrong { pcs }) => {
-                    for pc in pcs {
-                        sig.dyn_empty_lists.insert((fi as u32, pc));
+                // Summarized closure-returning functions are consumed at call
+                // sites; their pure bodies are never emitted.
+                if sig.ret_closures.get(fi).is_some_and(Option::is_some) {
+                    continue;
+                }
+                let is_entry = fi as u32 == module.entry;
+                let mut scratch = Vec::new();
+                let lowered = lower_function(
+                    &funcs[fi],
+                    funcs.as_slice(),
+                    fi as u32,
+                    module.entry,
+                    is_entry,
+                    &mut scratch,
+                    &module.globals,
+                    sig,
+                );
+                match lowered {
+                    Ok(mf) if !is_entry => {
+                        sig.ret_types[fi] = mf.ret;
+                        sig.ret_known[fi] = true;
                     }
+                    // A retriable loop-phi discovery: record it (the snapshot
+                    // includes the set's size, so the fixpoint runs again with
+                    // the phi pre-typed Dyn).
+                    Err(Unsupported::DynLoopPhi { block, slot }) => {
+                        sig.dyn_loop_phis.insert((fi as u32, block, slot));
+                    }
+                    Err(Unsupported::EmptyListGuessWrong { pcs }) => {
+                        for pc in pcs {
+                            sig.dyn_empty_lists.insert((fi as u32, pc));
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
+            }
+            // Materialize clones queued during this pass so the next pass lowers
+            // them (their `lambda_params` are already in place).
+            for orig in std::mem::take(&mut sig.pending_clones) {
+                funcs.push(funcs[orig as usize].clone());
+                reachable.push(true);
+            }
+            passes += 1;
+            // Field-by-field comparison against the pre-pass snapshot: the same
+            // convergence condition without cloning the whole state a second
+            // time. (A generation-counter scheme was evaluated and rejected:
+            // ~30 mutation sites to instrument, and one missed bump = false
+            // convergence = miscompile; the snapshot clone stays as the
+            // correctness anchor.)
+            let converged = snapshot.0 == sig.param_obs
+                && snapshot.1 == sig.ret_types
+                && snapshot.2 == sig.specializations.len()
+                && snapshot.3 == sig.ret_closures
+                && snapshot.4 == sig.dyn_loop_phis.len()
+                && snapshot.5 == sig.dyn_empty_lists.len()
+                && snapshot.6 == sig.dyn_rets.len()
+                && snapshot.7 == sig.global_tys
+                && snapshot.8 == sig.spawned_isolate.len()
+                && snapshot.9 == sig.force_dyn_globals.len();
+            // Each retriable discovery (Dyn loop phi, empty-list re-guess,
+            // boxed-returns function) legitimately consumes one extra pass, so
+            // the safety valve budgets for them on top of the type lattice.
+            let discovery_budget =
+                sig.dyn_loop_phis.len() + sig.dyn_empty_lists.len() + sig.dyn_rets.len() + sig.force_dyn_globals.len();
+            if converged || passes > 2 * funcs.len() + 2 + discovery_budget {
+                break;
             }
         }
-        // Materialize clones queued during this pass so the next pass lowers
-        // them (their `lambda_params` are already in place).
-        for orig in std::mem::take(&mut sig.pending_clones) {
-            funcs.push(funcs[orig as usize].clone());
-            reachable.push(true);
-        }
-        passes += 1;
-        // Field-by-field comparison against the pre-pass snapshot: the same
-        // convergence condition without cloning the whole state a second
-        // time. (A generation-counter scheme was evaluated and rejected:
-        // ~30 mutation sites to instrument, and one missed bump = false
-        // convergence = miscompile; the snapshot clone stays as the
-        // correctness anchor.)
-        let converged = snapshot.0 == sig.param_obs
-            && snapshot.1 == sig.ret_types
-            && snapshot.2 == sig.specializations.len()
-            && snapshot.3 == sig.ret_closures
-            && snapshot.4 == sig.dyn_loop_phis.len()
-            && snapshot.5 == sig.dyn_empty_lists.len()
-            && snapshot.6 == sig.dyn_rets.len()
-            && snapshot.7 == sig.global_tys
-            && snapshot.8 == sig.spawned_isolate.len()
-            && snapshot.9 == sig.force_dyn_globals.len();
-        // Each retriable discovery (Dyn loop phi, empty-list re-guess,
-        // boxed-returns function) legitimately consumes one extra pass, so
-        // the safety valve budgets for them on top of the type lattice.
-        let discovery_budget =
-            sig.dyn_loop_phis.len() + sig.dyn_empty_lists.len() + sig.dyn_rets.len() + sig.force_dyn_globals.len();
-        if converged || passes > 2 * funcs.len() + 2 + discovery_budget {
-            break;
-        }
-    }
+    };
+    refine_signatures(&mut sig, &mut funcs, &mut reachable);
     // A conflict that survives the *converged* pass is real (per-pass resets
     // clear transient marks left before a closure-return summary landed):
     // param-type disagreement or function-vs-value polymorphism.
@@ -293,7 +301,7 @@ pub fn lower_bundled(
     // function is bridge-eligible, in which case the pass reruns with those
     // functions marked VM-executed (their call sites emit `CallVm`, their bodies
     // are skipped). `FuncId`s keep their original module indices.
-    let final_pass = |sig: &mut SigInfer, reach: &[bool]| {
+    let final_pass = |sig: &mut SigInfer, reach: &[bool], funcs: &[FunctionData]| {
         // Same per-pass discipline as the fixpoint: `conflict` reflects *this*
         // pass only. A hybrid rerun re-derives every native function from
         // scratch, so a mark left by an earlier pass (a caller lowered
@@ -319,7 +327,7 @@ pub fn lower_bundled(
             let is_entry = fi as u32 == module.entry;
             match lower_function(
                 &funcs[fi],
-                &funcs,
+                funcs,
                 fi as u32,
                 module.entry,
                 is_entry,
@@ -333,7 +341,7 @@ pub fn lower_bundled(
         }
         (globals, functions, failures)
     };
-    let (mut globals, mut functions, failures) = final_pass(&mut sig, &reachable);
+    let (mut globals, mut functions, failures) = final_pass(&mut sig, &reachable, &funcs);
     if !failures.is_empty() {
         // `LK_AOT_DEBUG_FAILURES=1` lists every failing function (the
         // returned error is only the first; a callee's real blocker often
@@ -393,7 +401,11 @@ pub fn lower_bundled(
             // only ever called from inside the VM needs no bridge signature).
             sig.vm_functions
                 .retain(|fidx, _| native_reachable.get(*fidx as usize).copied().unwrap_or(false));
-            let (retry_globals, retry_functions, retry_failures) = final_pass(&mut sig, &native_reachable);
+            // Re-converge before emitting: the marks just added changed what
+            // the remaining native functions see.
+            let mut retry_reachable = native_reachable.clone();
+            refine_signatures(&mut sig, &mut funcs, &mut retry_reachable);
+            let (retry_globals, retry_functions, retry_failures) = final_pass(&mut sig, &retry_reachable, &funcs);
             if retry_failures.is_empty() {
                 globals = retry_globals;
                 functions = retry_functions;

--- a/aot/lower/src/lib.rs
+++ b/aot/lower/src/lib.rs
@@ -286,14 +286,29 @@ pub fn lower_bundled(
 
     // Compact numbering for the mutable globals the fixpoint discovered; the
     // final pass emits `GlobalGet`/`GlobalSet` against these ids.
-    let mut mutable_globals: Vec<(String, Ty)> = Vec::new();
-    for (slot, ty) in sig.global_tys.clone().into_iter().enumerate() {
-        if let Some(ty) = ty {
-            sig.gvar_of.insert(slot as u16, mutable_globals.len() as u32);
-            let name = sig.global_names.get(slot).cloned().unwrap_or_default();
-            mutable_globals.push((name, ty));
+    //
+    // Recomputed from scratch whenever signatures are re-converged, because
+    // lowering *discovers* globals: `inst/global.rs` fills `global_tys` as it
+    // sees accesses (`None → Some(ty)`, and a second, different observation
+    // widens to `Dyn`). Reusing the pre-rerun numbering would leave a
+    // newly-typed slot with no `gvar_of` entry, and `SigInfer::gvar` falls back
+    // to the raw slot number — which can *collide* with a compacted id and
+    // alias two distinct globals onto one cell, with nothing to reject it
+    // (`validate` only bounds-checks). A widened slot would likewise keep its
+    // stale declared `Ty` while the accessors moved to a register pair.
+    fn compact_mutable_globals(sig: &mut SigInfer) -> Vec<(String, Ty)> {
+        let mut mutable_globals: Vec<(String, Ty)> = Vec::new();
+        sig.gvar_of.clear();
+        for (slot, ty) in sig.global_tys.clone().into_iter().enumerate() {
+            if let Some(ty) = ty {
+                sig.gvar_of.insert(slot as u16, mutable_globals.len() as u32);
+                let name = sig.global_names.get(slot).cloned().unwrap_or_default();
+                mutable_globals.push((name, ty));
+            }
         }
+        mutable_globals
     }
+    let mut mutable_globals = compact_mutable_globals(&mut sig);
 
     // Final pass with stable signatures: produce the real MIR + interned globals for
     // the reachable functions. Any reachable function outside the subset fails the
@@ -402,13 +417,16 @@ pub fn lower_bundled(
             sig.vm_functions
                 .retain(|fidx, _| native_reachable.get(*fidx as usize).copied().unwrap_or(false));
             // Re-converge before emitting: the marks just added changed what
-            // the remaining native functions see.
+            // the remaining native functions see. The global numbering is derived
+            // from that same state, so it is rebuilt too.
             let mut retry_reachable = native_reachable.clone();
             refine_signatures(&mut sig, &mut funcs, &mut retry_reachable);
+            let retry_mutable_globals = compact_mutable_globals(&mut sig);
             let (retry_globals, retry_functions, retry_failures) = final_pass(&mut sig, &retry_reachable, &funcs);
             if retry_failures.is_empty() {
                 globals = retry_globals;
                 functions = retry_functions;
+                mutable_globals = retry_mutable_globals;
                 break;
             }
             if std::env::var_os("LK_AOT_DEBUG_FAILURES").is_some() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -901,9 +901,16 @@ pub(crate) fn build_vm_context(path: &Path) -> anyhow::Result<VmContext> {
     let mut registry = ModuleRegistry::new();
     register_enabled_stdlib(&mut registry)?;
     let mut resolver = ModuleResolver::with_registry(registry);
-    if let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) {
-        resolver.set_base_dir(parent.to_path_buf());
-    }
+    // A bare `lk main.lk` has an empty parent; that still means "the current
+    // directory", and it has to be set — the base directory is what establishes
+    // the import containment root, so skipping it disabled containment for
+    // exactly the most common invocation.
+    let base = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .map(std::path::Path::to_path_buf)
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    resolver.set_base_dir(base);
     configure_package_resolver(&mut resolver, path)?;
     let resolver = Arc::new(resolver);
     Ok(VmContext::new()

--- a/cli/src/native_compile.rs
+++ b/cli/src/native_compile.rs
@@ -3,6 +3,20 @@ use super::*;
 /// The lk-api C-ABI staticlib (VM + `lk_hybrid_*` bridge), built on demand.
 /// Shared by the Tier 0 bundle and the Tier 1 hybrid link.
 pub(super) fn ensure_lk_api_staticlib() -> anyhow::Result<PathBuf> {
+    // A caller that supplies its own `lkrt` (`LKRT_STATICLIB`) must be able to
+    // supply a matching `lk-api`. Both archives statically link `std`, so two
+    // *different rustc versions* each bring their own copy and the link fails on
+    // `multiple definition of rust_eh_personality` — which is exactly what the
+    // ASan harness hit: `scripts/build_lkrt_asan.sh` builds `lkrt` with nightly
+    // (`-Zsanitizer` needs it) while this built `lk-api` with the default
+    // toolchain. Only hybrid programs link `lk-api`, so only they failed.
+    if let Some(path) = std::env::var_os("LK_API_STATICLIB") {
+        let path = PathBuf::from(path);
+        if !path.exists() {
+            anyhow::bail!("LK_API_STATICLIB points at a missing file: {}", path.display());
+        }
+        return Ok(path);
+    }
     let workspace = workspace_root()?;
     let staticlib = workspace.join("target/release/liblk_api.a");
     if !staticlib.exists() {

--- a/cli/tests/clif_differential_test.rs
+++ b/cli/tests/clif_differential_test.rs
@@ -193,6 +193,61 @@ fn clif_differential_higher_order() {
 }
 
 /// A hybrid program (a helper that doesn't lower natively bridges to the VM):
+/// A value that came back from the bridge, fed to a *native* helper, whose result
+/// is then interpolated.
+///
+/// Marking a function VM-executed changes the type lattice, and signatures have
+/// to re-converge before the module is emitted. They did not: the final pass
+/// never wrote `ret_types` back, so `helper` — a native callee whose parameter
+/// widens to `Dyn` because its argument is bridge-tainted — kept its
+/// pre-marking return type at the call site. Interpolating that result emitted
+/// `str.from_i64` on a register pair, which only the Cranelift verifier caught,
+/// as an unreadable "Verifier errors". Found by the nightly fresh-seed fuzz
+/// (`LK_FUZZ_SEED=30198012768`), reduced here to compile in seconds.
+#[test]
+fn clif_differential_bridge_taint_reconverges_ret_types() {
+    let dir = unique_tmp_dir("bridge_taint");
+    let _ = fs::remove_dir_all(&dir);
+    create_dir_all(&dir).expect("create tmp dir");
+    let file = "taint.lk";
+    let src = "fn bridged(x) { let f = \"v={}\".trim(); println(f, x); return [x, x + 1]; }\n\
+               fn helper(a, b) { return (b - 25); }\n\
+               let got = bridged(1);\n\
+               let picked = helper(2, got[0]);\n\
+               println(\"p={}\", picked);\n\
+               return 0;\n";
+    File::create(dir.join(file))
+        .and_then(|mut f| f.write_all(src.as_bytes()))
+        .expect("write program");
+
+    let vm = run_cli(&dir, [file]).env("LK_FORCE_VM", "1").output().expect("vm run");
+    let vm_stdout = String::from_utf8_lossy(&vm.stdout).into_owned();
+
+    let compile = run_cli(&dir, ["compile", file])
+        .env("LK_AOT_NO_FALLBACK", "1")
+        .env("LK_AOT_HYBRID", "1")
+        .output()
+        .expect("hybrid compile");
+    let compile_stderr = String::from_utf8_lossy(&compile.stderr).into_owned();
+    assert!(compile.status.success(), "hybrid compile failed: {compile_stderr}");
+    assert!(
+        compile_stderr.contains("Tier 1 hybrid"),
+        "expected the hybrid link path, got: {compile_stderr}"
+    );
+
+    let native = Command::new(dir.join("taint"))
+        .env("ASAN_OPTIONS", "detect_leaks=0")
+        .output()
+        .expect("run executable");
+    assert_eq!(
+        vm_stdout,
+        String::from_utf8_lossy(&native.stdout),
+        "stdout must match the VM"
+    );
+    assert_eq!(vm.status.success(), native.status.success());
+    let _ = fs::remove_dir_all(&dir);
+}
+
 /// compiled through Cranelift with `LK_AOT_HYBRID` on and forced clif-only, the
 /// stderr must show the Cranelift hybrid link (not a fallback) and stdout must
 /// match the VM — including native/VM print ordering across the bridge.

--- a/cli/tests/compile_cli_test.rs
+++ b/cli/tests/compile_cli_test.rs
@@ -780,6 +780,60 @@ fn test_trait_impl_from_imported_file_dispatches() {
     let _ = fs::remove_dir_all(&dir);
 }
 
+/// One trait may be implemented for a builtin type only once across the whole
+/// program.
+///
+/// A builtin has no declaring module, so every module's impls for it share one
+/// scope and the later registration silently overwrote the earlier: with two
+/// modules implementing `Doubler for Int`, `(5).dbl()` answered whichever was
+/// imported *last*, so moving a `use` line changed the result.
+#[test]
+fn test_overlapping_builtin_impl_is_rejected() {
+    let dir = unique_tmp_dir("builtin_impl_overlap");
+    ensure_clean_dir(&dir);
+    for (file, factor) in [("modA.lk", 2), ("modB.lk", 3)] {
+        write_file(
+            &dir,
+            file,
+            &format!(
+                "trait Doubler {{ fn dbl(self) -> Int; }}\n\
+                 impl Doubler for Int {{ fn dbl(self) -> Int {{ return self * {factor}; }} }}\n\
+                 fn mk() -> Int {{ return 1; }}\n"
+            ),
+        );
+    }
+
+    // One module implementing it is fine.
+    write_file(
+        &dir,
+        "one.lk",
+        "use * as A from \"./modA\";\nprintln(A.mk());\nprintln((5).dbl());\n",
+    );
+    let out = run_cli(&dir, ["one.lk"]).output().expect("spawn run");
+    assert!(out.status.success(), "{}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim().lines().collect::<Vec<_>>(),
+        ["1", "10"]
+    );
+
+    // Two is the overlap, and it must be reported rather than resolved by
+    // import order.
+    write_file(
+        &dir,
+        "both.lk",
+        "use * as A from \"./modA\";\nuse * as B from \"./modB\";\nprintln((5).dbl());\n",
+    );
+    let out = run_cli(&dir, ["both.lk"]).output().expect("spawn run");
+    assert!(!out.status.success(), "an overlapping builtin impl must not run");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("conflicting `impl Doubler for Int`"),
+        "the error must name the trait and the type, got: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
 /// `try`/`catch` is a statement, not a closure — three things that were wrong
 /// while it was rewritten in the parser into `try$call(|| { body })`.
 ///

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -105,28 +105,12 @@ impl Stmt {
                     };
                 }
 
-                // Extract variables from pattern and add their types to the type checker
-                if let Some(pattern_vars) = extract_pattern_variables(pattern) {
-                    // A single-variable pattern binds the expression's type. A
-                    // *destructuring* one does not: giving every element the type
-                    // of the whole value is simply wrong (`let [ok, v] = f()`
-                    // where `f` returns a tuple would type `v` as that tuple),
-                    // and it stayed invisible only while inference was too coarse
-                    // to produce a precise enough right-hand side. Distributing a
-                    // pattern over a type — tuple positions, list elements, and
-                    // over each member of a union — is the real fix; until then
-                    // the binding is `Any`, which is honest about what is known
-                    // and never rejects on a type it invented.
-                    let destructuring = !matches!(pattern, crate::expr::Pattern::Variable(_));
-                    let var_type = match type_annotation.clone() {
-                        Some(annotated) => annotated,
-                        None if destructuring => Type::Any,
-                        None => expr_type,
-                    };
-                    for var_name in pattern_vars {
-                        type_checker.add_local_binding(var_name, var_type.clone(), *is_const);
-                    }
-                }
+                // The pattern is distributed over the value's type, so each name
+                // gets *its own* element type. Binding the whole right-hand side
+                // to every name (what this used to do) types `v` in
+                // `let [ok, v] = f()` as the entire tuple.
+                let bound_type = type_annotation.clone().unwrap_or(expr_type);
+                bind_pattern_types(pattern, &bound_type, *is_const, type_checker);
 
                 Ok(())
             }
@@ -859,49 +843,86 @@ impl Program {
     }
 }
 
-/// Helper method to extract variable names from a pattern for type checking
-fn extract_pattern_variables(pattern: &Pattern) -> Option<Vec<String>> {
-    let mut variables = Vec::new();
+/// Binds every name in `pattern` to the type that position holds in `value_ty`.
+///
+/// Distribution, not the whole value: a list/tuple pattern takes tuple positions
+/// or the list's element type, a map pattern takes the map's value type, and a
+/// union distributes into a union of what each member yields. Anything this
+/// cannot see through (a type variable, `Any`, a mismatched shape) yields `Any`
+/// — permissive on purpose, so an unknown shape never rejects on an invented
+/// type.
+fn bind_pattern_types(pattern: &Pattern, value_ty: &Type, is_const: bool, tc: &mut TypeChecker) {
+    match pattern {
+        Pattern::Variable(name) => tc.add_local_binding(name.clone(), value_ty.clone(), is_const),
+        Pattern::List { patterns, rest } => {
+            for (index, sub) in patterns.iter().enumerate() {
+                bind_pattern_types(sub, &element_type_at(value_ty, index), is_const, tc);
+            }
+            if let Some(rest) = rest {
+                // The tail keeps the container's own shape: a list of the same
+                // element type. Positions are lost, hence `List`, not `Tuple`.
+                let tail = match element_type_at(value_ty, patterns.len()) {
+                    Type::Any => Type::Any,
+                    element => Type::List(Box::new(element)),
+                };
+                tc.add_local_binding(rest.clone(), tail, is_const);
+            }
+        }
+        Pattern::Map { patterns, rest } => {
+            for (_, sub) in patterns {
+                bind_pattern_types(sub, &map_value_type(value_ty), is_const, tc);
+            }
+            if let Some(rest) = rest {
+                tc.add_local_binding(rest.clone(), value_ty.clone(), is_const);
+            }
+        }
+        // A guard does not change what the inner pattern binds; alternatives bind
+        // the same names, so each alternative is distributed independently.
+        Pattern::Guard { pattern, .. } => bind_pattern_types(pattern, value_ty, is_const, tc),
+        Pattern::Or(alternatives) => {
+            for alternative in alternatives {
+                bind_pattern_types(alternative, value_ty, is_const, tc);
+            }
+        }
+        Pattern::Literal(_) | Pattern::Wildcard | Pattern::Range { .. } => {}
+    }
+}
 
-    fn collect_vars(pattern: &Pattern, vars: &mut Vec<String>) {
-        match pattern {
-            Pattern::Variable(name) => {
-                vars.push(name.clone());
-            }
-            Pattern::List { patterns, rest } => {
-                for pattern in patterns {
-                    collect_vars(pattern, vars);
-                }
-                if let Some(rest_var) = rest {
-                    vars.push(rest_var.clone());
-                }
-            }
-            Pattern::Map { patterns, rest } => {
-                for (_, pattern) in patterns {
-                    collect_vars(pattern, vars);
-                }
-                if let Some(rest_var) = rest {
-                    vars.push(rest_var.clone());
-                }
-            }
-            Pattern::Or(patterns) => {
-                for pattern in patterns {
-                    collect_vars(pattern, vars);
-                }
-            }
-            Pattern::Guard { pattern, .. } => {
-                collect_vars(pattern, vars);
-            }
-            // Other pattern types don't bind variables
-            Pattern::Literal(_) | Pattern::Wildcard | Pattern::Range { .. } => {}
+/// The type at position `index` of a destructured value.
+fn element_type_at(value_ty: &Type, index: usize) -> Type {
+    match value_ty {
+        Type::Tuple(elements) => elements.get(index).cloned().unwrap_or(Type::Any),
+        Type::List(element) => (**element).clone(),
+        Type::Optional(inner) => element_type_at(inner, index),
+        Type::Union(members) => union_of(members.iter().map(|member| element_type_at(member, index))),
+        _ => Type::Any,
+    }
+}
+
+fn map_value_type(value_ty: &Type) -> Type {
+    match value_ty {
+        Type::Map(_, value) => (**value).clone(),
+        Type::Optional(inner) => map_value_type(inner),
+        Type::Union(members) => union_of(members.iter().map(map_value_type)),
+        _ => Type::Any,
+    }
+}
+
+/// Collapses distributed alternatives: identical types stay themselves, `Any`
+/// anywhere swallows the rest (nothing is known), otherwise a union.
+fn union_of(types: impl IntoIterator<Item = Type>) -> Type {
+    let mut out: Vec<Type> = Vec::new();
+    for ty in types {
+        if ty == Type::Any {
+            return Type::Any;
+        }
+        if !out.contains(&ty) {
+            out.push(ty);
         }
     }
-
-    collect_vars(pattern, &mut variables);
-
-    // Remove duplicates (can happen with OR patterns)
-    variables.sort();
-    variables.dedup();
-
-    if variables.is_empty() { None } else { Some(variables) }
+    match out.len() {
+        0 => Type::Any,
+        1 => out.pop().expect("checked len"),
+        _ => Type::Union(out),
+    }
 }

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -310,85 +310,14 @@ impl Stmt {
                     },
                 );
 
-                // A function body's block scope *is* the function scope, so its
-                // statements are checked directly here rather than through
-                // `Stmt::Block` — which pushes a scope and pops it, discarding
-                // the body's bindings before `collect_return_types` below runs.
-                // That is why an annotated local came back as a fresh type
-                // variable: `fn f() -> Int { let r: Int = 0; r = 7; return r; }`
-                // reported "expected Int, got 'T0", because `r` was unknown by
-                // the time `return r` was inferred. The function's own scope
-                // (pushed above, popped below) still bounds the bindings.
-                match body.as_ref() {
-                    Stmt::Block { statements } => {
-                        for stmt in statements {
-                            stmt.type_check(type_checker)?;
-                        }
-                    }
-                    other => other.type_check(type_checker)?,
-                }
-
-                fn collect_return_types(stmt: &Stmt, tc: &mut TypeChecker, out: &mut Vec<Type>) -> anyhow::Result<()> {
-                    match stmt {
-                        Stmt::Return { value } => {
-                            if let Some(expr) = value {
-                                let ty = expr.type_check(tc)?;
-                                out.push(ty);
-                            } else {
-                                out.push(Type::Nil);
-                            }
-                        }
-                        Stmt::If {
-                            condition,
-                            then_stmt,
-                            else_stmt,
-                        } => {
-                            let _ = condition.type_check(tc)?;
-                            collect_return_types(then_stmt, tc, out)?;
-                            if let Some(es) = else_stmt.as_deref() {
-                                collect_return_types(es, tc, out)?;
-                            }
-                        }
-                        Stmt::IfLet {
-                            then_stmt,
-                            else_stmt,
-                            value: _,
-                            pattern: _,
-                        } => {
-                            collect_return_types(then_stmt, tc, out)?;
-                            if let Some(es) = else_stmt.as_deref() {
-                                collect_return_types(es, tc, out)?;
-                            }
-                        }
-                        Stmt::While { condition, body } => {
-                            let _ = condition.type_check(tc)?;
-                            collect_return_types(body, tc, out)?;
-                        }
-                        Stmt::WhileLet { body, .. } => {
-                            collect_return_types(body, tc, out)?;
-                        }
-                        Stmt::For { body, .. } => {
-                            collect_return_types(body, tc, out)?;
-                        }
-                        // A `try` body's `return` returns from *this* function
-                        // (that is what `Stmt::Try` fixed), so both sides have to
-                        // be collected or the declared return type goes
-                        // unchecked: `fn f() -> Int { try { return "s"; } … }`
-                        // passed `lk check` silently.
-                        Stmt::Try { body, handler, .. } => {
-                            for s in body.iter().chain(handler) {
-                                collect_return_types(s, tc, out)?;
-                            }
-                        }
-                        Stmt::Block { statements } => {
-                            for s in statements {
-                                collect_return_types(s, tc, out)?;
-                            }
-                        }
-                        _ => {}
-                    }
-                    Ok(())
-                }
+                // The frame collects every `return` as it is checked, while its
+                // scope is still live (see `TypeChecker::push_return_frame`). A
+                // traversal *after* the body sees every nested `if`/`while`/`for`/
+                // `try` scope already popped, which is why an annotated local
+                // returned from inside one came back as a fresh type variable.
+                type_checker.push_return_frame();
+                body.type_check(type_checker)?;
+                let collected_returns = type_checker.pop_return_frame();
 
                 fn normalize_union(mut tys: Vec<Type>) -> Type {
                     let mut flat: Vec<Type> = Vec::new();
@@ -410,9 +339,6 @@ impl Stmt {
                         Type::Union(uniq)
                     }
                 }
-
-                let mut collected_returns: Vec<Type> = Vec::new();
-                collect_return_types(body, type_checker, &mut collected_returns)?;
 
                 if return_was_annotated {
                     for ty in &collected_returns {
@@ -724,7 +650,18 @@ impl Stmt {
                 // Use 语句暂时不需要类型检查
                 Ok(())
             }
-            Stmt::Break | Stmt::Continue | Stmt::Return { .. } => {
+            Stmt::Return { value } => {
+                // Recorded here rather than by a traversal after the body: this is
+                // the only point at which the returned expression's scope is still
+                // live (see `TypeChecker::push_return_frame`).
+                let ty = match value {
+                    Some(expr) => expr.type_check(type_checker)?,
+                    None => Type::Nil,
+                };
+                type_checker.record_return(ty);
+                Ok(())
+            }
+            Stmt::Break | Stmt::Continue => {
                 // 控制流语句暂时不需要类型检查
                 Ok(())
             }
@@ -907,7 +844,16 @@ fn tail_element_type(value_ty: &Type, from: usize) -> Type {
 fn element_type_at(value_ty: &Type, index: usize) -> Type {
     match value_ty {
         Type::Tuple(elements) => elements.get(index).cloned().unwrap_or(Type::Any),
-        Type::List(element) => (**element).clone(),
+        // A `List<T>`'s element type applies to every position — except when `T`
+        // is itself a union, which is the *join* over positions rather than what
+        // any one of them holds (a heterogeneous literal can infer
+        // `List<Int | String>`). Claiming the union per position would reject
+        // `let [first, _] = [1, {…}]; first + 1`, so the honest answer for a lost
+        // per-position type is `Any`.
+        Type::List(element) => match &**element {
+            Type::Union(_) => Type::Any,
+            element => element.clone(),
+        },
         Type::Optional(inner) => element_type_at(inner, index),
         Type::Union(members) => union_of(members.iter().map(|member| element_type_at(member, index))),
         _ => Type::Any,
@@ -916,7 +862,13 @@ fn element_type_at(value_ty: &Type, index: usize) -> Type {
 
 fn map_value_type(value_ty: &Type) -> Type {
     match value_ty {
-        Type::Map(_, value) => (**value).clone(),
+        // As with a list's element type: a union value type is the join over *all*
+        // keys, not what the key this pattern names holds, so binding the union
+        // would reject legitimate uses of the extracted value.
+        Type::Map(_, value) => match &**value {
+            Type::Union(_) => Type::Any,
+            value => value.clone(),
+        },
         Type::Optional(inner) => map_value_type(inner),
         Type::Union(members) => union_of(members.iter().map(map_value_type)),
         _ => Type::Any,

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -859,9 +859,12 @@ fn bind_pattern_types(pattern: &Pattern, value_ty: &Type, is_const: bool, tc: &m
                 bind_pattern_types(sub, &element_type_at(value_ty, index), is_const, tc);
             }
             if let Some(rest) = rest {
-                // The tail keeps the container's own shape: a list of the same
-                // element type. Positions are lost, hence `List`, not `Tuple`.
-                let tail = match element_type_at(value_ty, patterns.len()) {
+                // The tail holds *every* remaining position, so its element type
+                // is their union — taking only position `patterns.len()` typed
+                // `rest` of a `Tuple<Int, String, Bool>` as `List<String>`, which
+                // both rejected `rest[1]` as a `Bool` and accepted `rest` as a
+                // `List<String>`. Positions themselves are lost, hence `List`.
+                let tail = match tail_element_type(value_ty, patterns.len()) {
                     Type::Any => Type::Any,
                     element => Type::List(Box::new(element)),
                 };
@@ -885,6 +888,18 @@ fn bind_pattern_types(pattern: &Pattern, value_ty: &Type, is_const: bool, tc: &m
             }
         }
         Pattern::Literal(_) | Pattern::Wildcard | Pattern::Range { .. } => {}
+    }
+}
+
+/// The element type of everything from position `from` onward — what a `..rest`
+/// binding holds.
+fn tail_element_type(value_ty: &Type, from: usize) -> Type {
+    match value_ty {
+        Type::Tuple(elements) => union_of(elements.iter().skip(from).cloned()),
+        Type::List(element) => (**element).clone(),
+        Type::Optional(inner) => tail_element_type(inner, from),
+        Type::Union(members) => union_of(members.iter().map(|member| tail_element_type(member, from))),
+        _ => Type::Any,
     }
 }
 

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -107,7 +107,22 @@ impl Stmt {
 
                 // Extract variables from pattern and add their types to the type checker
                 if let Some(pattern_vars) = extract_pattern_variables(pattern) {
-                    let var_type = type_annotation.clone().unwrap_or(expr_type);
+                    // A single-variable pattern binds the expression's type. A
+                    // *destructuring* one does not: giving every element the type
+                    // of the whole value is simply wrong (`let [ok, v] = f()`
+                    // where `f` returns a tuple would type `v` as that tuple),
+                    // and it stayed invisible only while inference was too coarse
+                    // to produce a precise enough right-hand side. Distributing a
+                    // pattern over a type — tuple positions, list elements, and
+                    // over each member of a union — is the real fix; until then
+                    // the binding is `Any`, which is honest about what is known
+                    // and never rejects on a type it invented.
+                    let destructuring = !matches!(pattern, crate::expr::Pattern::Variable(_));
+                    let var_type = match type_annotation.clone() {
+                        Some(annotated) => annotated,
+                        None if destructuring => Type::Any,
+                        None => expr_type,
+                    };
                     for var_name in pattern_vars {
                         type_checker.add_local_binding(var_name, var_type.clone(), *is_const);
                     }
@@ -311,7 +326,23 @@ impl Stmt {
                     },
                 );
 
-                body.type_check(type_checker)?;
+                // A function body's block scope *is* the function scope, so its
+                // statements are checked directly here rather than through
+                // `Stmt::Block` — which pushes a scope and pops it, discarding
+                // the body's bindings before `collect_return_types` below runs.
+                // That is why an annotated local came back as a fresh type
+                // variable: `fn f() -> Int { let r: Int = 0; r = 7; return r; }`
+                // reported "expected Int, got 'T0", because `r` was unknown by
+                // the time `return r` was inferred. The function's own scope
+                // (pushed above, popped below) still bounds the bindings.
+                match body.as_ref() {
+                    Stmt::Block { statements } => {
+                        for stmt in statements {
+                            stmt.type_check(type_checker)?;
+                        }
+                    }
+                    other => other.type_check(type_checker)?,
+                }
 
                 fn collect_return_types(stmt: &Stmt, tc: &mut TypeChecker, out: &mut Vec<Type>) -> anyhow::Result<()> {
                     match stmt {

--- a/core/src/stmt/stmt_impl/type_check.rs
+++ b/core/src/stmt/stmt_impl/type_check.rs
@@ -315,9 +315,13 @@ impl Stmt {
                 // traversal *after* the body sees every nested `if`/`while`/`for`/
                 // `try` scope already popped, which is why an annotated local
                 // returned from inside one came back as a fresh type variable.
+                // Popped on both paths, like the closure case: propagating the
+                // body's error through `?` before popping would leave a dead frame
+                // on the stack for an enclosing function's returns to land in.
                 type_checker.push_return_frame();
-                body.type_check(type_checker)?;
+                let body_checked = body.type_check(type_checker);
                 let collected_returns = type_checker.pop_return_frame();
+                body_checked?;
 
                 fn normalize_union(mut tys: Vec<Type>) -> Type {
                     let mut flat: Vec<Type> = Vec::new();

--- a/core/src/typ/type_checker.rs
+++ b/core/src/typ/type_checker.rs
@@ -79,6 +79,15 @@ pub struct TypeChecker {
     pending_strict_functions: Vec<PendingStrictFunction>,
     /// Program-level type checking enables this so later call sites can refine earlier function declarations.
     defer_strict_function_checks: bool,
+    /// Return types observed while checking the body of the function (or closure)
+    /// currently being checked, innermost last.
+    ///
+    /// Collected *during* the walk because that is the only time a `return`'s
+    /// scope is still live. A second traversal afterwards sees every nested
+    /// `if`/`while`/`for`/`try` scope already popped, so
+    /// `fn f() -> Int { if c { let r: Int = 7; return r; } … }` inferred `r` as a
+    /// fresh type variable and rejected valid code.
+    return_frames: Vec<Vec<Type>>,
 }
 
 impl Default for TypeChecker {
@@ -157,6 +166,7 @@ impl TypeChecker {
             method_sigs: HashMap::new(),
             pending_strict_functions: Vec::new(),
             defer_strict_function_checks: false,
+            return_frames: Vec::new(),
         }
     }
 
@@ -362,6 +372,24 @@ impl TypeChecker {
     }
 
     /// Enter a new scope for local variables
+    /// Opens a return-collection frame for a function or closure body.
+    pub fn push_return_frame(&mut self) {
+        self.return_frames.push(Vec::new());
+    }
+
+    /// Closes the innermost frame and yields the return types seen in it.
+    pub fn pop_return_frame(&mut self) -> Vec<Type> {
+        self.return_frames.pop().unwrap_or_default()
+    }
+
+    /// Records a `return`'s type against the innermost frame. Outside any
+    /// function body (a top-level `return`) there is nothing to collect.
+    pub fn record_return(&mut self, ty: Type) {
+        if let Some(frame) = self.return_frames.last_mut() {
+            frame.push(ty);
+        }
+    }
+
     pub fn push_scope(&mut self) {
         // Snapshot current locals; modifications in the new scope are discarded on pop
         self.scope_stack.push(self.local_types.clone());

--- a/core/src/typ/type_checker.rs
+++ b/core/src/typ/type_checker.rs
@@ -371,7 +371,6 @@ impl TypeChecker {
         &mut self.registry
     }
 
-    /// Enter a new scope for local variables
     /// Opens a return-collection frame for a function or closure body.
     pub fn push_return_frame(&mut self) {
         self.return_frames.push(Vec::new());
@@ -390,6 +389,7 @@ impl TypeChecker {
         }
     }
 
+    /// Enter a new scope for local variables
     pub fn push_scope(&mut self) {
         // Snapshot current locals; modifications in the new scope are discarded on pop
         self.scope_stack.push(self.local_types.clone());

--- a/core/src/typ/type_checker/expressions.rs
+++ b/core/src/typ/type_checker/expressions.rs
@@ -444,8 +444,14 @@ impl TypeChecker {
                 for _ in params {
                     param_types.push(self.inference_engine.fresh_type_var());
                 }
-                // Body type is inferred by checking the body expression
-                let ret_type = self.check_expr(body)?;
+                // Body type is inferred by checking the body expression. Its own
+                // return frame: a `return` inside a closure body belongs to the
+                // closure, and must not be collected as a return of the enclosing
+                // function (whose declared type it would then have to satisfy).
+                self.push_return_frame();
+                let ret_type = self.check_expr(body);
+                let _ = self.pop_return_frame();
+                let ret_type = ret_type?;
                 Ok(Type::Function {
                     params: param_types,
                     named_params: Vec::new(),

--- a/core/src/vm/compiler/builder.rs
+++ b/core/src/vm/compiler/builder.rs
@@ -182,7 +182,7 @@ impl Compiler {
         }
         // Checked rather than `as i16`: a protected region longer than the
         // signed-bx range must fail the compile, not wrap into a jump to
-        // somewhere else. (`patch_branch` above still truncates — TODO.)
+        // somewhere else.
         let offset = i16::try_from(jump_offset(pc, target)?)
             .map_err(|_| anyhow!("Compiler try region at pc {pc} is too large to encode a handler offset"))?;
         self.function.code[pc] = Instr::as_bx(Opcode::TryBegin, instr.a(), offset);
@@ -330,7 +330,12 @@ impl Compiler {
         ) {
             bail!("Compiler expected branch at patch pc {pc}");
         }
-        self.function.code[pc] = Instr::as_bx(instr.opcode(), instr.a(), jump_offset(pc, target)? as i16);
+        // Checked, not `as i16`: a branch target outside the signed-bx range
+        // silently wrapped into a jump somewhere else instead of failing the
+        // compile. (`patch_try_begin` below was written this way from the start.)
+        let offset = i16::try_from(jump_offset(pc, target)?)
+            .map_err(|_| anyhow!("Compiler branch at pc {pc} is too far to encode ({target})"))?;
+        self.function.code[pc] = Instr::as_bx(instr.opcode(), instr.a(), offset);
         Ok(())
     }
 

--- a/core/src/vm/compiler/tests/misc.rs
+++ b/core/src/vm/compiler/tests/misc.rs
@@ -1054,3 +1054,65 @@ fn annotated_local_is_visible_to_the_declared_return_type() {
         assert!(err.to_string().contains("Return type mismatch"), "got: {err}");
     }
 }
+
+/// A destructuring `let` binds each name to *its own* element type.
+///
+/// It used to bind the whole right-hand side to every name, so `v` in
+/// `let [ok, v] = pick()` was typed as the entire tuple — invisible only while
+/// inference was too coarse to produce a precise enough right-hand side.
+#[test]
+fn destructuring_let_distributes_the_pattern_over_the_type() {
+    let check = |src: &str| -> anyhow::Result<()> {
+        let program = crate::syntax::parse_program_source(src, crate::syntax::ParseOptions::default()).expect("parse");
+        let mut tc = crate::typ::TypeChecker::new();
+        program.statements.iter().try_for_each(|stmt| stmt.type_check(&mut tc))
+    };
+
+    // `Tuple<Bool, String>` gives `v: String` — usable as a string…
+    check(
+        "fn pick() -> Tuple<Bool, String> { return [true, \"x\"]; }\n\
+         let [ok, v] = pick();\n\
+         let s: String = v;\n\
+         return 0;\n",
+    )
+    .expect("the second element is a String");
+
+    // …and *only* as a string.
+    let err = check(
+        "fn pick() -> Tuple<Bool, String> { return [true, \"x\"]; }\n\
+         let [ok, v] = pick();\n\
+         let n: Int = v;\n\
+         return 0;\n",
+    )
+    .expect_err("an element's type is now checked");
+    assert!(err.to_string().contains("Int"), "got: {err}");
+
+    // A `List<T>` distributes its element type to every position, and `..rest`
+    // keeps the container shape.
+    check(
+        "fn nums() -> List<Int> { return [1, 2, 3]; }\n\
+         let [a, ..tail] = nums();\n\
+         let x: Int = a;\n\
+         let t: List<Int> = tail;\n\
+         return 0;\n",
+    )
+    .expect("list elements and tail distribute");
+}
+
+/// `Tuple<..>` in an annotation is the `Tuple` type, not a user generic that
+/// merely *displays* the same.
+///
+/// `Type::parse` handled `List`/`Map`/`Set`/`Task`/`Channel` but not `Tuple`, so
+/// the annotation became `Generic { name: "Tuple" }` while a heterogeneous list
+/// literal infers `Type::Tuple` — hence "expected Tuple<Bool, String>, got
+/// Tuple<Bool, String>".
+#[test]
+fn tuple_annotation_parses_as_the_tuple_type() {
+    assert_eq!(
+        crate::val::Type::parse("Tuple<Bool, String>"),
+        Some(crate::val::Type::Tuple(vec![
+            crate::val::Type::Bool,
+            crate::val::Type::String
+        ]))
+    );
+}

--- a/core/src/vm/compiler/tests/misc.rs
+++ b/core/src/vm/compiler/tests/misc.rs
@@ -1038,11 +1038,32 @@ fn annotated_local_is_visible_to_the_declared_return_type() {
             .expect("an annotated local satisfies the declared return type");
     }
 
-    // Still rejects a genuinely wrong return, including inside a `try` body
-    // (whose `return` returns from this function).
+    // Every nested body too: returns are collected as each one is checked, so a
+    // local declared inside an `if`/`while`/`for`/`try` is still in scope when its
+    // `return` is inferred. A traversal after the body saw them all popped.
+    for nested in [
+        "if (1 == 1) { let r: Int = 7; return r; } return 0;",
+        "while (1 == 1) { let r: Int = 7; return r; } return 0;",
+        "for i in 0..1 { let r: Int = 7; return r; } return 0;",
+        "try { let r: Int = 7; return r; } catch e { return 0; }",
+    ] {
+        let src = format!("fn f() -> Int {{ {nested} }}\nreturn f();\n");
+        let program = crate::syntax::parse_program_source(&src, crate::syntax::ParseOptions::default()).expect("parse");
+        let mut tc = crate::typ::TypeChecker::new();
+        program
+            .statements
+            .iter()
+            .try_for_each(|stmt| stmt.type_check(&mut tc))
+            .unwrap_or_else(|err| panic!("`{nested}` should type-check: {err}"));
+    }
+
+    // Still rejects a genuinely wrong return, from any nesting depth.
     for bad in [
         "fn f() -> Int { let r: Int = 0; return \"s\"; }\nreturn 0;\n",
         "fn f() -> Int { try { return \"s\"; } catch e { return 1; } }\nreturn 0;\n",
+        "fn f() -> Int { if (1 == 1) { return \"s\"; } return 0; }\nreturn 0;\n",
+        "fn f() -> Int { for i in 0..1 { return \"s\"; } return 0; }\nreturn 0;\n",
+        "fn f() -> Int { while (1 == 1) { return \"s\"; } return 0; }\nreturn 0;\n",
     ] {
         let program = crate::syntax::parse_program_source(bad, crate::syntax::ParseOptions::default()).expect("parse");
         let mut tc = crate::typ::TypeChecker::new();

--- a/core/src/vm/compiler/tests/misc.rs
+++ b/core/src/vm/compiler/tests/misc.rs
@@ -1018,3 +1018,39 @@ fn impl_methods_record_how_their_subtree_uses_globals() {
         Some("pure")
     );
 }
+
+/// A function body's block scope *is* the function scope, so an annotated local
+/// is still known when the declared return type is validated.
+///
+/// It was not: the body was checked through `Stmt::Block`, which pushes a scope
+/// and pops it, so `collect_return_types` inferred `return r` with `r` unknown
+/// and reported "expected Int, got 'T0" for perfectly well-typed code.
+#[test]
+fn annotated_local_is_visible_to_the_declared_return_type() {
+    let ok = crate::syntax::parse_program_source(
+        "fn f() -> Int { let r: Int = 0; r = 7; return r; }\nreturn f();\n",
+        crate::syntax::ParseOptions::default(),
+    )
+    .expect("parse");
+    let mut tc = crate::typ::TypeChecker::new();
+    for stmt in &ok.statements {
+        stmt.type_check(&mut tc)
+            .expect("an annotated local satisfies the declared return type");
+    }
+
+    // Still rejects a genuinely wrong return, including inside a `try` body
+    // (whose `return` returns from this function).
+    for bad in [
+        "fn f() -> Int { let r: Int = 0; return \"s\"; }\nreturn 0;\n",
+        "fn f() -> Int { try { return \"s\"; } catch e { return 1; } }\nreturn 0;\n",
+    ] {
+        let program = crate::syntax::parse_program_source(bad, crate::syntax::ParseOptions::default()).expect("parse");
+        let mut tc = crate::typ::TypeChecker::new();
+        let err = program
+            .statements
+            .iter()
+            .try_for_each(|stmt| stmt.type_check(&mut tc))
+            .expect_err("a wrong return type must still be rejected");
+        assert!(err.to_string().contains("Return type mismatch"), "got: {err}");
+    }
+}

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -570,7 +570,11 @@ impl VmContext {
 /// would let it collide with every other module's.
 fn impl_target_scope(target_type: &str, declaring: &crate::vm::TypeScope) -> crate::vm::TypeScope {
     match Type::parse(target_type) {
-        Some(Type::Named(_)) | None => declaring.clone(),
+        // A user *generic* (`Wrapper<Int>` → `Type::Generic`) is as module-local
+        // as a plain `Named`: two modules may each declare their own `Wrapper`.
+        // Lumping it in with the builtins made them share one coherence key and
+        // conflict with each other.
+        Some(Type::Named(_)) | Some(Type::Generic { .. }) | None => declaring.clone(),
         Some(_) => crate::vm::TypeScope::builtin(),
     }
 }

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -86,6 +86,16 @@ pub struct VmContext {
     /// on every object it constructs. Set by the loader, which knows the path;
     /// the compiler does not (see [`crate::vm::TypeScope`]).
     type_scope: crate::vm::TypeScope,
+    /// Which module declared each `impl Trait for <builtin>` — keyed by
+    /// `(type name, trait name)`.
+    ///
+    /// A builtin type has no declaring module, so every module's impls for it
+    /// share one scope (see [`crate::vm::TypeScope::builtin`]) and the later
+    /// registration used to overwrite the earlier one *silently*: with two
+    /// modules implementing `Doubler for Int`, `(5).dbl()` answered whichever
+    /// was imported last, so moving a `use` line changed the result. Recording
+    /// the owner turns the overlap into an error at registration.
+    builtin_impl_owner: FastHashMap<(String, String), crate::vm::TypeScope>,
     call_stack: Vec<CallFrameInfo>,
     /// Per-context handle to the async (tokio) runtime. Replaces the former
     /// process-global runtime; clones (spawned tasks, shallow clones) share the
@@ -129,6 +139,7 @@ impl VmContext {
             structs: fast_hash_map_new(),
             methods: fast_hash_map_new(),
             type_scope: crate::vm::TypeScope::anonymous(),
+            builtin_impl_owner: fast_hash_map_new(),
             call_stack: Vec::new(),
             async_runtime: crate::rt::AsyncRuntimeHandle::new(),
         }
@@ -153,6 +164,7 @@ impl VmContext {
             structs: self.structs.clone(),
             methods: self.methods.clone(),
             type_scope: self.type_scope.clone(),
+            builtin_impl_owner: self.builtin_impl_owner.clone(),
             call_stack: self.call_stack.clone(),
             // Share the same async runtime so spawned tasks run on one reactor.
             async_runtime: self.async_runtime.clone(),
@@ -391,6 +403,40 @@ impl VmContext {
         self.methods.get(scope)?.get(type_name)?.get(method)
     }
 
+    /// Records `decl` as the owner of `impl <trait> for <builtin type>`, or fails
+    /// if a *different* module already owns it.
+    ///
+    /// Only builtin targets need this: a declared type is scoped to its own
+    /// module, so two modules' `Point` impls never meet. `Int`/`List`/… have no
+    /// declaring module, so the pair is global and admits exactly one impl.
+    /// Re-registering the same module (REPL, hybrid bridge, transitive imports)
+    /// is fine — it is the *same* owner.
+    fn claim_builtin_impl(
+        &mut self,
+        scope: &crate::vm::TypeScope,
+        declaring: &crate::vm::TypeScope,
+        type_name: &str,
+        trait_name: &str,
+    ) -> Result<()> {
+        if !scope.is_builtin() {
+            return Ok(());
+        }
+        let key = (type_name.to_string(), trait_name.to_string());
+        match self.builtin_impl_owner.get(&key) {
+            Some(owner) if owner != declaring => Err(anyhow!(
+                "conflicting `impl {trait_name} for {type_name}`: already implemented by {}, now by {}. \
+                 A builtin type has no declaring module, so one trait can be implemented for it only once \
+                 — otherwise which one runs depends on import order",
+                owner.as_str(),
+                declaring.as_str()
+            )),
+            _ => {
+                self.builtin_impl_owner.insert(key, declaring.clone());
+                Ok(())
+            }
+        }
+    }
+
     /// Records an imported module's trait impls, bound to *that* module's
     /// function table and heap.
     ///
@@ -398,15 +444,17 @@ impl VmContext {
     /// importer executed the file in a throwaway `VmContext` and kept only its
     /// exported values, so `use { make } from "./shape.lk"; make(4).area()`
     /// failed with "Object has no method 'area'".
-    pub fn register_imported_types(&mut self, export: &RuntimeExport) {
+    pub fn register_imported_types(&mut self, export: &RuntimeExport) -> Result<()> {
         let module = export.shared_module();
         if module.type_info.is_empty() {
-            return;
+            return Ok(());
         }
         for decl in &module.type_info.impls {
+            let scope = impl_target_scope(&decl.type_name, &module.type_scope);
+            self.claim_builtin_impl(&scope, &module.type_scope, &decl.type_name, &decl.trait_name)?;
             let by_method = self
                 .methods
-                .entry(impl_target_scope(&decl.type_name, &module.type_scope))
+                .entry(scope)
                 .or_default()
                 .entry(decl.type_name.clone())
                 .or_default();
@@ -422,6 +470,7 @@ impl VmContext {
                 );
             }
         }
+        Ok(())
     }
 
     /// Populates the runtime method table from the module's compiled
@@ -482,9 +531,11 @@ impl VmContext {
         // declared it (see `MethodImpl::Local`) and filed under that module's
         // scope, so an identically-named type elsewhere keeps its own entry.
         for decl in &type_info.impls {
+            let scope = impl_target_scope(&decl.type_name, &module.type_scope);
+            self.claim_builtin_impl(&scope, &module.type_scope, &decl.type_name, &decl.trait_name)?;
             let by_method = self
                 .methods
-                .entry(impl_target_scope(&decl.type_name, &module.type_scope))
+                .entry(scope)
                 .or_default()
                 .entry(decl.type_name.clone())
                 .or_default();

--- a/core/src/vm/context.rs
+++ b/core/src/vm/context.rs
@@ -488,6 +488,13 @@ impl VmContext {
         if type_info.is_empty() {
             return Ok(());
         }
+        // Coherence first, before *any* registry mutation: `register_trait_impl`
+        // below writes into the checker, so claiming ownership from the dispatch
+        // loop afterwards left a rejected module half-registered.
+        for decl in &type_info.impls {
+            let scope = impl_target_scope(&decl.type_name, &module.type_scope);
+            self.claim_builtin_impl(&scope, &module.type_scope, &decl.type_name, &decl.trait_name)?;
+        }
         // Checker registration only happens when there *is* a checker; the
         // dispatch table below is unconditional. Returning early without one
         // used to skip both, so a context built without a type checker could
@@ -532,7 +539,6 @@ impl VmContext {
         // scope, so an identically-named type elsewhere keeps its own entry.
         for decl in &type_info.impls {
             let scope = impl_target_scope(&decl.type_name, &module.type_scope);
-            self.claim_builtin_impl(&scope, &module.type_scope, &decl.type_name, &decl.trait_name)?;
             let by_method = self
                 .methods
                 .entry(scope)

--- a/core/src/vm/exec/handler.rs
+++ b/core/src/vm/exec/handler.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "std"))]
-use crate::compat::prelude::*;
 use alloc::sync::Arc;
 
 use anyhow::{Result, anyhow, bail};

--- a/core/src/vm/resolver.rs
+++ b/core/src/vm/resolver.rs
@@ -44,6 +44,17 @@ pub struct ModuleResolver {
     search_paths: Vec<PathBuf>,
     /// Package modules resolved from Lk.toml dependencies/workspace members
     package_modules: Arc<SharedMap<String, PathBuf>>,
+    /// The directory a file import may not escape: the package root (the nearest
+    /// ancestor with an `Lk.toml`), falling back to the importing file's own
+    /// directory when there is no manifest.
+    ///
+    /// `..` in an import path is *allowed* — `use "../general/fib";` is used by
+    /// the examples — so the boundary is containment, not a ban on `..`. Set per
+    /// loaded file (`set_base_dir`), which is what makes it "a package's imports
+    /// cannot leave that package": a dependency loaded from elsewhere gets its
+    /// own root, not the importer's.
+    #[cfg(feature = "std")]
+    containment_root: Option<PathBuf>,
 }
 
 impl PartialEq for ModuleResolver {
@@ -66,6 +77,8 @@ impl ModuleResolver {
             // Prefer current directory; also allow `core/` for workspace runs.
             search_paths: vec![PathBuf::from("."), PathBuf::from("core")],
             package_modules: Arc::new(SharedMap::new()),
+            #[cfg(feature = "std")]
+            containment_root: None,
         }
     }
 
@@ -105,6 +118,37 @@ impl ModuleResolver {
         self.add_search_path(base.clone());
         self.add_search_path(base.join("lib"));
         self.add_search_path(base.join("modules"));
+        // Canonicalized *before* the manifest search: `find_manifest` walks
+        // parents, and a relative base like `.` has none to walk — the package
+        // root would silently come back as `.` itself.
+        let anchor = base.canonicalize().unwrap_or(base);
+        let root = crate::package::find_manifest(&anchor)
+            .and_then(|manifest| manifest.parent().map(Path::to_path_buf))
+            .unwrap_or(anchor);
+        self.containment_root = Some(root.canonicalize().unwrap_or(root));
+    }
+
+    /// Whether `candidate` is inside the containment root (see the field docs).
+    /// Unset root — a resolver that was never given a base directory, e.g. the
+    /// in-memory registry-only one — contains everything.
+    #[cfg(feature = "std")]
+    fn within_containment_root(&self, candidate: &Path) -> bool {
+        let Some(root) = &self.containment_root else {
+            return true;
+        };
+        let resolved = candidate.canonicalize();
+        resolved.as_deref().unwrap_or(candidate).starts_with(root)
+    }
+
+    #[cfg(feature = "std")]
+    fn escaped_containment_root(&self, requested: &Path, candidate: &Path) -> anyhow::Error {
+        anyhow!(
+            "import '{}' resolves to '{}', which is outside '{}' — an import may not leave its package \
+             (the nearest directory with an Lk.toml, or the importing file's directory when there is none)",
+            requested.display(),
+            candidate.display(),
+            self.containment_root.as_deref().unwrap_or(Path::new(".")).display()
+        )
     }
 
     /// Register a package root module. `use name;` resolves to this file when
@@ -213,12 +257,10 @@ impl ModuleResolver {
     pub fn resolve_file_path(&self, path: &str) -> Result<PathBuf> {
         let path = Path::new(path);
 
-        // Only relative import paths are accepted. `..` is *not* rejected —
-        // `use "../general/fib";` is supported and used by the examples — so
-        // the `starts_with(root)` checks below are a normalization preference,
-        // not containment: a candidate that escapes its root is still returned.
-        // Tightening that into real containment needs a decision about which
-        // root a `..` import is allowed to escape into. TODO(security): decide.
+        // Only relative import paths are accepted, and a relative one must still
+        // resolve *inside* the containment root — `..` is allowed as a way to
+        // reach a sibling directory of the same package, not as a way out of it
+        // (see `containment_root`).
         if !path.is_relative() {
             return Err(anyhow!(
                 "Absolute paths are not allowed for imports: {}",
@@ -232,40 +274,36 @@ impl ModuleResolver {
         // If the input already contains an extension, also allow it directly.
         let base = PathBuf::from(path);
 
+        // Accepting a candidate is where containment is enforced. The
+        // `starts_with(root)` tests below are a *normalization* preference (use
+        // the canonical form when it stays under the search root) and were never
+        // a boundary — the fallback returned the path either way.
+        let accept = |candidate: PathBuf| -> Result<PathBuf> {
+            if !self.within_containment_root(&candidate) {
+                return Err(self.escaped_containment_root(path, &candidate));
+            }
+            Ok(Self::normalize_path(candidate.canonicalize().unwrap_or(candidate)))
+        };
+
         for root in &self.search_paths {
             // If the input already includes .lk and exists under this root, accept it
             if base.extension().and_then(|s| s.to_str()) == Some("lk") {
                 let p = root.join(&base);
                 if p.exists() {
-                    if let Ok(canon) = p.canonicalize()
-                        && canon.starts_with(root)
-                    {
-                        return Ok(Self::normalize_path(canon));
-                    }
-                    return Ok(Self::normalize_path(p));
+                    return accept(p);
                 }
             }
 
             // Try ${MOD_NAME}.lk
             let candidate1 = root.join(base.with_extension("lk"));
             if candidate1.exists() {
-                if let Ok(canon) = candidate1.canonicalize()
-                    && canon.starts_with(root)
-                {
-                    return Ok(Self::normalize_path(canon));
-                }
-                return Ok(Self::normalize_path(candidate1));
+                return accept(candidate1);
             }
 
             // Try ${MOD_NAME}/mod.lk
             let candidate2 = root.join(base.join("mod.lk"));
             if candidate2.exists() {
-                if let Ok(canon) = candidate2.canonicalize()
-                    && canon.starts_with(root)
-                {
-                    return Ok(Self::normalize_path(canon));
-                }
-                return Ok(Self::normalize_path(candidate2));
+                return accept(candidate2);
             }
         }
 
@@ -324,7 +362,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
             let module = resolve_runtime_import_source(source, resolver)?;
             // An imported module's `impl` blocks must dispatch here too; the
             // methods stay bound to their own module and heap.
-            env.register_imported_types(&module);
+            env.register_imported_types(&module)?;
             for item in items {
                 let symbol_name = item.alias.as_ref().unwrap_or(&item.name);
                 let export = runtime_export_field(&module, &item.name)?;
@@ -336,7 +374,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
         match import {
             ImportStmt::Module { module } => {
                 let module_export = resolver.resolve_runtime_module(module)?;
-                env.register_imported_types(&module_export);
+                env.register_imported_types(&module_export)?;
                 env.define_runtime_global(default_module_binding(module), module_export);
             }
             ImportStmt::File { path } => {
@@ -349,7 +387,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
                         .unwrap_or("module")
                         .to_string();
                     let module = resolver.resolve_runtime_file(path)?;
-                    env.register_imported_types(&module);
+                    env.register_imported_types(&module)?;
                     env.define_runtime_global(module_name, module);
                 }
                 #[cfg(not(feature = "std"))]
@@ -361,7 +399,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
             ImportStmt::Items { .. } => unreachable!("items imports are handled before runtime use binding"),
             ImportStmt::Namespace { alias, source } => {
                 let module = resolve_runtime_import_source(source, resolver)?;
-                env.register_imported_types(&module);
+                env.register_imported_types(&module)?;
                 env.define_runtime_global(alias.clone(), module);
             }
             ImportStmt::ModuleAlias { module, alias } => {
@@ -369,7 +407,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
                 // Same order as every other variant: an aliased module's trait
                 // impls have to be registered too, or `use shape as s;`
                 // dispatches worse than `use shape;`.
-                env.register_imported_types(&module_export);
+                env.register_imported_types(&module_export)?;
                 env.define_runtime_global(alias.clone(), module_export);
             }
         }
@@ -383,7 +421,7 @@ pub fn execute_imports(imports: &[ImportStmt], resolver: &ModuleResolver, env: &
     // modules cannot clobber anything (see `vm::TypeScope`).
     #[cfg(feature = "std")]
     for module in resolver.loaded_file_modules() {
-        env.register_imported_types(&module);
+        env.register_imported_types(&module)?;
     }
     Ok(())
 }
@@ -520,13 +558,57 @@ mod tests {
         let abs_str = abs.to_string_lossy().to_string();
         assert!(resolver.resolve_file_path(&abs_str).is_err());
 
-        // Parent directory components are now allowed (relative to source file)
-        // but must stay within a search_path root
-
         // Relative simple path that likely does not exist should return not found
         // (error message still OK but not due to security check)
         let rel = PathBuf::from("does_not_exist.lk");
         assert!(resolver.resolve_file_path(&rel.to_string_lossy()).is_err());
+    }
+
+    /// `..` is allowed as a way to reach a sibling directory of the same package,
+    /// not as a way out of it. The boundary is the package root (nearest
+    /// `Lk.toml`), or the importing file's directory when there is no manifest.
+    #[test]
+    fn resolve_file_path_contains_parent_traversal() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let outside = temp.path().join("outside.lk");
+        std::fs::write(&outside, "return nil;\n")?;
+        let proj = temp.path().join("proj");
+        std::fs::create_dir_all(proj.join("sub"))?;
+        std::fs::write(proj.join("sibling.lk"), "return nil;\n")?;
+        std::fs::write(proj.join("sub").join("inner.lk"), "return nil;\n")?;
+
+        // No manifest: the importing file's directory is the boundary.
+        let mut resolver = ModuleResolver::new();
+        resolver.set_base_dir(proj.join("sub"));
+        assert!(
+            resolver.resolve_file_path("inner").is_ok(),
+            "a sibling inside the boundary resolves"
+        );
+        let escaped = resolver.resolve_file_path("../sibling");
+        assert!(escaped.is_err(), "`..` may not leave the boundary");
+        assert!(
+            escaped.unwrap_err().to_string().contains("outside"),
+            "the error must say what boundary was crossed"
+        );
+        assert!(resolver.resolve_file_path("../../outside").is_err());
+
+        // With a manifest above, the package root is the boundary, so the same
+        // `..` import now resolves.
+        std::fs::write(
+            proj.join(crate::package::MANIFEST_FILE),
+            "name = \"t\"\nversion = \"0.1.0\"\n",
+        )?;
+        let mut resolver = ModuleResolver::new();
+        resolver.set_base_dir(proj.join("sub"));
+        assert!(
+            resolver.resolve_file_path("../sibling").is_ok(),
+            "`..` inside the package is fine"
+        );
+        assert!(
+            resolver.resolve_file_path("../../outside").is_err(),
+            "but not out of the package"
+        );
+        Ok(())
     }
 
     #[test]

--- a/core/src/vm/resolver.rs
+++ b/core/src/vm/resolver.rs
@@ -140,6 +140,8 @@ impl ModuleResolver {
         resolved.as_deref().unwrap_or(candidate).starts_with(root)
     }
 
+    /// `candidate` is expected already canonicalized — the raw join (`././x.lk`)
+    /// says nothing about *which* directory was left.
     #[cfg(feature = "std")]
     fn escaped_containment_root(&self, requested: &Path, candidate: &Path) -> anyhow::Error {
         anyhow!(
@@ -274,37 +276,40 @@ impl ModuleResolver {
         // If the input already contains an extension, also allow it directly.
         let base = PathBuf::from(path);
 
-        // Accepting a candidate is where containment is enforced. The
-        // `starts_with(root)` tests below are a *normalization* preference (use
-        // the canonical form when it stays under the search root) and were never
-        // a boundary — the fallback returned the path either way.
-        let accept = |candidate: PathBuf| -> Result<PathBuf> {
-            if !self.within_containment_root(&candidate) {
-                return Err(self.escaped_containment_root(path, &candidate));
-            }
-            Ok(Self::normalize_path(candidate.canonicalize().unwrap_or(candidate)))
-        };
-
+        // Containment is enforced per candidate, and an out-of-root candidate
+        // *skips* rather than failing the search: `search_paths` always starts
+        // with `.` and `core`, which have nothing to do with the importing file's
+        // directory whenever cwd differs from it. Returning an error on the first
+        // escape meant a name that also existed in cwd shadowed — and hard-failed
+        // — an import whose real target sat under a later root.
+        //
+        // (The `starts_with(root)` tests this replaced were a *normalization*
+        // preference, never a boundary: the fallback returned the path anyway.)
+        let mut escaped: Option<PathBuf> = None;
         for root in &self.search_paths {
-            // If the input already includes .lk and exists under this root, accept it
-            if base.extension().and_then(|s| s.to_str()) == Some("lk") {
-                let p = root.join(&base);
-                if p.exists() {
-                    return accept(p);
+            let candidates = [
+                // The input already includes `.lk`.
+                (base.extension().and_then(|s| s.to_str()) == Some("lk")).then(|| root.join(&base)),
+                Some(root.join(base.with_extension("lk"))),
+                Some(root.join(base.join("mod.lk"))),
+            ];
+            for candidate in candidates.into_iter().flatten() {
+                if !candidate.exists() {
+                    continue;
                 }
+                let resolved = candidate.canonicalize().unwrap_or(candidate);
+                if !self.within_containment_root(&resolved) {
+                    escaped.get_or_insert(resolved);
+                    continue;
+                }
+                return Ok(Self::normalize_path(resolved));
             }
+        }
 
-            // Try ${MOD_NAME}.lk
-            let candidate1 = root.join(base.with_extension("lk"));
-            if candidate1.exists() {
-                return accept(candidate1);
-            }
-
-            // Try ${MOD_NAME}/mod.lk
-            let candidate2 = root.join(base.join("mod.lk"));
-            if candidate2.exists() {
-                return accept(candidate2);
-            }
+        // Nothing in-root matched. If some candidate *did* exist but sat outside,
+        // that is the useful diagnosis — a plain "not found" would hide it.
+        if let Some(escaped) = escaped {
+            return Err(self.escaped_containment_root(path, &escaped));
         }
 
         Err(anyhow!(
@@ -591,6 +596,19 @@ mod tests {
             "the error must say what boundary was crossed"
         );
         assert!(resolver.resolve_file_path("../../outside").is_err());
+
+        // An out-of-root candidate must *skip*, not abort the search: a name that
+        // also exists in cwd (always the first search path) would otherwise
+        // hard-fail an import whose real target sits under a later root.
+        let cwd_shadow = std::env::current_dir()?.join("shadowed.lk");
+        std::fs::write(&cwd_shadow, "return nil;\n")?;
+        std::fs::write(proj.join("sub").join("shadowed.lk"), "return nil;\n")?;
+        let resolved = resolver.resolve_file_path("shadowed");
+        let _ = std::fs::remove_file(&cwd_shadow);
+        assert!(
+            resolved.is_ok(),
+            "the in-root candidate must win over an out-of-root shadow: {resolved:?}"
+        );
 
         // With a manifest above, the package root is the boundary, so the same
         // `..` import now resolves.

--- a/core/src/vm/resolver.rs
+++ b/core/src/vm/resolver.rs
@@ -8,7 +8,10 @@
 //! `stmt::import` now holds only the syntax (`ImportStmt` and friends) and the
 //! AST walk that collects them.
 
-use crate::compat::path::{Path, PathBuf};
+use crate::compat::path::PathBuf;
+// File loading — and therefore every `Path` use — is a `std` surface.
+#[cfg(feature = "std")]
+use crate::compat::path::Path;
 #[cfg(not(feature = "std"))]
 use crate::compat::prelude::*;
 use crate::compat::shared_map::SharedMap;
@@ -31,7 +34,11 @@ use std::path::Component;
 pub struct ModuleResolver {
     /// Standard library registry
     stdlib_registry: Arc<ModuleRegistry>,
-    /// Loaded file modules as new VM runtime exports.
+    /// Loaded file modules as new VM runtime exports. Only ever read by the
+    /// `std`-gated file-loading path; without `std` there are no files to load,
+    /// so the map stays empty rather than the field being conditional (that
+    /// would have to be threaded through every constructor and clone).
+    #[cfg_attr(not(feature = "std"), allow(dead_code))]
     runtime_file_modules: Arc<SharedMap<PathBuf, RuntimeExport>>,
     /// Search paths for module resolution
     search_paths: Vec<PathBuf>,

--- a/core/src/vm/type_info.rs
+++ b/core/src/vm/type_info.rs
@@ -115,6 +115,12 @@ impl TypeScope {
         Self(Arc::<str>::from("<builtin>"))
     }
 
+    /// Whether this is the shared scope for builtin types (see
+    /// [`Self::builtin`]), which admits only one impl per trait.
+    pub fn is_builtin(&self) -> bool {
+        self.0.as_ref() == "<builtin>"
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/examples/Lk.toml
+++ b/examples/Lk.toml
@@ -1,2 +1,3 @@
+[package]
 name = "lk-examples"
 version = "0.1.0"

--- a/examples/Lk.toml
+++ b/examples/Lk.toml
@@ -1,0 +1,2 @@
+name = "lk-examples"
+version = "0.1.0"

--- a/lkrt/src/lkdyn.rs
+++ b/lkrt/src/lkdyn.rs
@@ -834,8 +834,19 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_map_fn(handle: *mut c_void, f: extern "
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = dyn_slice(handle).to_vec();
-    let mapped: Vec<LkDyn> = values.into_iter().map(|v| f(v)).collect();
+    // Indexed, re-dereferencing the handle each step: `f`/`p` re-enters generated
+    // code, which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past a borrow, so none may be held across the call. Re-deref rather
+    // than a `to_vec()` snapshot — this is the native HOF hot path the perf gate
+    // measures.
+    let len = dyn_slice(handle).len();
+    let mut mapped: Vec<LkDyn> = Vec::with_capacity(len);
+    for index in 0..len {
+        let Some(&value) = dyn_slice(handle).get(index) else {
+            break;
+        };
+        mapped.push(f(value));
+    }
     arena_handle(mapped)
 }
 
@@ -853,8 +864,21 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_filter_fn(
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = dyn_slice(handle).to_vec();
-    let kept: Vec<LkDyn> = values.into_iter().filter(|&v| p(v)).collect();
+    // Indexed, re-dereferencing the handle each step: `f`/`p` re-enters generated
+    // code, which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past a borrow, so none may be held across the call. Re-deref rather
+    // than a `to_vec()` snapshot — this is the native HOF hot path the perf gate
+    // measures.
+    let len = dyn_slice(handle).len();
+    let mut kept: Vec<LkDyn> = Vec::new();
+    for index in 0..len {
+        let Some(&value) = dyn_slice(handle).get(index) else {
+            break;
+        };
+        if p(value) {
+            kept.push(value);
+        }
+    }
     arena_handle(kept)
 }
 
@@ -873,8 +897,20 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_reduce_fn(
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = dyn_slice(handle).to_vec();
-    values.into_iter().fold(init, |acc, v| f(acc, v))
+    // Indexed, re-dereferencing the handle each step: `f`/`p` re-enters generated
+    // code, which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past a borrow, so none may be held across the call. Re-deref rather
+    // than a `to_vec()` snapshot — this is the native HOF hot path the perf gate
+    // measures.
+    let len = dyn_slice(handle).len();
+    let mut acc = init;
+    for index in 0..len {
+        let Some(&value) = dyn_slice(handle).get(index) else {
+            break;
+        };
+        acc = f(acc, value);
+    }
+    acc
 }
 
 /// `xs.chunk(size)` — split into `size`-element groups, last group short.

--- a/lkrt/src/lkdyn.rs
+++ b/lkrt/src/lkdyn.rs
@@ -828,7 +828,14 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_chain(a: *mut c_void, b: *mut c_void) -
 /// `handle` must be a live dyn-list handle (or null); `f` a compiled lambda.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lkrt_lklist_dyn_map_fn(handle: *mut c_void, f: extern "C" fn(LkDyn) -> LkDyn) -> *mut c_void {
-    let mapped: Vec<LkDyn> = dyn_slice(handle).iter().map(|&v| f(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = dyn_slice(handle).to_vec();
+    let mapped: Vec<LkDyn> = values.into_iter().map(|v| f(v)).collect();
     arena_handle(mapped)
 }
 
@@ -840,7 +847,14 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_filter_fn(
     handle: *mut c_void,
     p: extern "C" fn(LkDyn) -> bool,
 ) -> *mut c_void {
-    let kept: Vec<LkDyn> = dyn_slice(handle).iter().copied().filter(|&v| p(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = dyn_slice(handle).to_vec();
+    let kept: Vec<LkDyn> = values.into_iter().filter(|&v| p(v)).collect();
     arena_handle(kept)
 }
 
@@ -853,7 +867,14 @@ pub unsafe extern "C" fn lkrt_lklist_dyn_reduce_fn(
     init: LkDyn,
     f: extern "C" fn(LkDyn, LkDyn) -> LkDyn,
 ) -> LkDyn {
-    dyn_slice(handle).iter().fold(init, |acc, &v| f(acc, v))
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = dyn_slice(handle).to_vec();
+    values.into_iter().fold(init, |acc, v| f(acc, v))
 }
 
 /// `xs.chunk(size)` — split into `size`-element groups, last group short.

--- a/lkrt/src/lklist.rs
+++ b/lkrt/src/lklist.rs
@@ -13,29 +13,58 @@
 
 use std::ffi::{CStr, CString, c_char, c_void};
 
-/// The live `str`-list behind a handle, re-derived per element so no borrow is
-/// held across a callback into generated code.
+/// Length of the `str` list behind a handle; `0` for null.
+///
+/// Length and element reads are separate calls, and each *copies out*, so a
+/// caller cannot hold a reference into the list across a callback into generated
+/// code — the whole point of reading this way. Returning a slice would have to
+/// invent a lifetime for a borrow of an opaque pointer.
 ///
 /// # Safety
 /// `handle` must be a live `str` list handle, or null.
-unsafe fn list_str(handle: *mut c_void) -> &'static [*const c_char] {
+unsafe fn list_str_len(handle: *mut c_void) -> usize {
     if handle.is_null() {
-        return &[];
+        return 0;
     }
-    // SAFETY: as the callers' contracts state.
-    unsafe { &*(handle as *mut Vec<*const c_char>) }
+    // SAFETY: as the caller's contract states.
+    unsafe { &*(handle as *mut Vec<*const c_char>) }.len()
 }
 
-/// As [`list_str`], for an `i64` list.
+/// Element `index` of the `str` list behind a handle, copied out. `None` past the
+/// end (which a callback that shrank the list can produce).
+///
+/// # Safety
+/// As [`list_str_len`].
+unsafe fn list_str_at(handle: *mut c_void, index: usize) -> Option<*const c_char> {
+    if handle.is_null() {
+        return None;
+    }
+    // SAFETY: as the caller's contract states.
+    unsafe { &*(handle as *mut Vec<*const c_char>) }.get(index).copied()
+}
+
+/// As [`list_str_len`], for an `i64` list.
 ///
 /// # Safety
 /// `handle` must be a live `i64` list handle, or null.
-unsafe fn list_i64(handle: *mut c_void) -> &'static [i64] {
+unsafe fn list_i64_len(handle: *mut c_void) -> usize {
     if handle.is_null() {
-        return &[];
+        return 0;
     }
-    // SAFETY: as the callers' contracts state.
-    unsafe { &*(handle as *mut Vec<i64>) }
+    // SAFETY: as the caller's contract states.
+    unsafe { &*(handle as *mut Vec<i64>) }.len()
+}
+
+/// As [`list_str_at`], for an `i64` list.
+///
+/// # Safety
+/// As [`list_i64_len`].
+unsafe fn list_i64_at(handle: *mut c_void, index: usize) -> Option<i64> {
+    if handle.is_null() {
+        return None;
+    }
+    // SAFETY: as the caller's contract states.
+    unsafe { &*(handle as *mut Vec<i64>) }.get(index).copied()
 }
 
 /// Creates a fresh, empty `i64` list handle.
@@ -112,12 +141,6 @@ pub unsafe extern "C" fn lkrt_lklist_str_map_fn(
     handle: *mut c_void,
     f: extern "C" fn(*const c_char) -> *const c_char,
 ) -> *mut c_void {
-    let values: &[*const c_char] = if handle.is_null() {
-        &[]
-    } else {
-        // SAFETY: `handle` addresses a `Vec<*const c_char>` from `lkrt_lklist_str_new`.
-        unsafe { &*(handle as *mut Vec<*const c_char>) }
-    };
     // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
     // which can push to *this* list (reallocating its buffer) or raise and
     // longjmp past the borrow — either way a slice held across the call is
@@ -132,11 +155,12 @@ pub unsafe extern "C" fn lkrt_lklist_str_map_fn(
     // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
     // native HOF hot path the perf gate measures, and copying the whole input on
     // top of the result allocation is not free.
-    let len = values.len();
+    // SAFETY: the handle is live per this function's contract.
+    let len = unsafe { list_str_len(handle) };
     let mut mapped: Vec<*const c_char> = Vec::with_capacity(len);
     for index in 0..len {
         // SAFETY: the handle is live per this function's contract.
-        let Some(&value) = unsafe { list_str(handle) }.get(index) else {
+        let Some(value) = (unsafe { list_str_at(handle, index) }) else {
             break;
         };
         mapped.push(f(value));
@@ -153,12 +177,6 @@ pub unsafe extern "C" fn lkrt_lklist_str_filter_fn(
     handle: *mut c_void,
     p: extern "C" fn(*const c_char) -> bool,
 ) -> *mut c_void {
-    let values: &[*const c_char] = if handle.is_null() {
-        &[]
-    } else {
-        // SAFETY: as above.
-        unsafe { &*(handle as *mut Vec<*const c_char>) }
-    };
     // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
     // which can push to *this* list (reallocating its buffer) or raise and
     // longjmp past the borrow — either way a slice held across the call is
@@ -173,11 +191,12 @@ pub unsafe extern "C" fn lkrt_lklist_str_filter_fn(
     // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
     // native HOF hot path the perf gate measures, and copying the whole input on
     // top of the result allocation is not free.
-    let len = values.len();
+    // SAFETY: the handle is live per this function's contract.
+    let len = unsafe { list_str_len(handle) };
     let mut kept: Vec<*const c_char> = Vec::new();
     for index in 0..len {
         // SAFETY: the handle is live per this function's contract.
-        let Some(&value) = unsafe { list_str(handle) }.get(index) else {
+        let Some(value) = (unsafe { list_str_at(handle, index) }) else {
             break;
         };
         if p(value) {
@@ -294,12 +313,6 @@ pub extern "C" fn lkrt_lklist_i64_new() -> *mut c_void {
 /// valid `extern "C" fn(i64) -> i64` (a lowered `@lk_fn_N`).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lkrt_lklist_i64_map_fn(handle: *mut c_void, f: extern "C" fn(i64) -> i64) -> *mut c_void {
-    let values: &[i64] = if handle.is_null() {
-        &[]
-    } else {
-        // SAFETY: `handle` addresses a `Vec<i64>` created by `lkrt_lklist_i64_new`.
-        unsafe { &*(handle as *mut Vec<i64>) }
-    };
     // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
     // which can push to *this* list (reallocating its buffer) or raise and
     // longjmp past the borrow — either way a slice held across the call is
@@ -314,11 +327,12 @@ pub unsafe extern "C" fn lkrt_lklist_i64_map_fn(handle: *mut c_void, f: extern "
     // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
     // native HOF hot path the perf gate measures, and copying the whole input on
     // top of the result allocation is not free.
-    let len = values.len();
+    // SAFETY: the handle is live per this function's contract.
+    let len = unsafe { list_i64_len(handle) };
     let mut mapped: Vec<i64> = Vec::with_capacity(len);
     for index in 0..len {
         // SAFETY: the handle is live per this function's contract.
-        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+        let Some(value) = (unsafe { list_i64_at(handle, index) }) else {
             break;
         };
         mapped.push(f(value));
@@ -332,12 +346,6 @@ pub unsafe extern "C" fn lkrt_lklist_i64_map_fn(handle: *mut c_void, f: extern "
 /// See [`lkrt_lklist_i64_map_fn`]; `p` returns the lambda's `Bool`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn lkrt_lklist_i64_filter_fn(handle: *mut c_void, p: extern "C" fn(i64) -> bool) -> *mut c_void {
-    let values: &[i64] = if handle.is_null() {
-        &[]
-    } else {
-        // SAFETY: as above.
-        unsafe { &*(handle as *mut Vec<i64>) }
-    };
     // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
     // which can push to *this* list (reallocating its buffer) or raise and
     // longjmp past the borrow — either way a slice held across the call is
@@ -352,11 +360,12 @@ pub unsafe extern "C" fn lkrt_lklist_i64_filter_fn(handle: *mut c_void, p: exter
     // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
     // native HOF hot path the perf gate measures, and copying the whole input on
     // top of the result allocation is not free.
-    let len = values.len();
+    // SAFETY: the handle is live per this function's contract.
+    let len = unsafe { list_i64_len(handle) };
     let mut kept: Vec<i64> = Vec::new();
     for index in 0..len {
         // SAFETY: the handle is live per this function's contract.
-        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+        let Some(value) = (unsafe { list_i64_at(handle, index) }) else {
             break;
         };
         if p(value) {
@@ -470,12 +479,6 @@ pub unsafe extern "C" fn lkrt_lklist_i64_reduce_fn(
     init: i64,
     f: extern "C" fn(i64, i64) -> i64,
 ) -> i64 {
-    let values: &[i64] = if handle.is_null() {
-        &[]
-    } else {
-        // SAFETY: as above.
-        unsafe { &*(handle as *mut Vec<i64>) }
-    };
     // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
     // which can push to *this* list (reallocating its buffer) or raise and
     // longjmp past the borrow — either way a slice held across the call is
@@ -490,11 +493,12 @@ pub unsafe extern "C" fn lkrt_lklist_i64_reduce_fn(
     // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
     // native HOF hot path the perf gate measures, and copying the whole input on
     // top of the result allocation is not free.
-    let len = values.len();
+    // SAFETY: the handle is live per this function's contract.
+    let len = unsafe { list_i64_len(handle) };
     let mut acc = init;
     for index in 0..len {
         // SAFETY: the handle is live per this function's contract.
-        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+        let Some(value) = (unsafe { list_i64_at(handle, index) }) else {
             break;
         };
         acc = f(acc, value);

--- a/lkrt/src/lklist.rs
+++ b/lkrt/src/lklist.rs
@@ -93,7 +93,14 @@ pub unsafe extern "C" fn lkrt_lklist_str_map_fn(
         // SAFETY: `handle` addresses a `Vec<*const c_char>` from `lkrt_lklist_str_new`.
         unsafe { &*(handle as *mut Vec<*const c_char>) }
     };
-    let mapped: Vec<*const c_char> = values.iter().map(|&v| f(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = values.to_vec();
+    let mapped: Vec<*const c_char> = values.into_iter().map(|v| f(v)).collect();
     crate::state::arena_handle(mapped)
 }
 
@@ -112,7 +119,14 @@ pub unsafe extern "C" fn lkrt_lklist_str_filter_fn(
         // SAFETY: as above.
         unsafe { &*(handle as *mut Vec<*const c_char>) }
     };
-    let kept: Vec<*const c_char> = values.iter().copied().filter(|&v| p(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = values.to_vec();
+    let kept: Vec<*const c_char> = values.into_iter().filter(|&v| p(v)).collect();
     crate::state::arena_handle(kept)
 }
 
@@ -229,7 +243,14 @@ pub unsafe extern "C" fn lkrt_lklist_i64_map_fn(handle: *mut c_void, f: extern "
         // SAFETY: `handle` addresses a `Vec<i64>` created by `lkrt_lklist_i64_new`.
         unsafe { &*(handle as *mut Vec<i64>) }
     };
-    let mapped: Vec<i64> = values.iter().map(|&v| f(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = values.to_vec();
+    let mapped: Vec<i64> = values.into_iter().map(|v| f(v)).collect();
     crate::state::arena_handle(mapped)
 }
 
@@ -245,7 +266,14 @@ pub unsafe extern "C" fn lkrt_lklist_i64_filter_fn(handle: *mut c_void, p: exter
         // SAFETY: as above.
         unsafe { &*(handle as *mut Vec<i64>) }
     };
-    let kept: Vec<i64> = values.iter().copied().filter(|&v| p(v)).collect();
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = values.to_vec();
+    let kept: Vec<i64> = values.into_iter().filter(|&v| p(v)).collect();
     crate::state::arena_handle(kept)
 }
 
@@ -359,7 +387,14 @@ pub unsafe extern "C" fn lkrt_lklist_i64_reduce_fn(
         // SAFETY: as above.
         unsafe { &*(handle as *mut Vec<i64>) }
     };
-    values.iter().fold(init, |acc, &v| f(acc, v))
+    // Snapshotted before the callback runs. `f`/`p` re-enters generated code,
+    // which can push to *this* list (reallocating its buffer) or raise and
+    // longjmp past the borrow — either way a slice held across the call is
+    // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
+    // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
+    // is just a third way to hold one.
+    let values = values.to_vec();
+    values.into_iter().fold(init, |acc, v| f(acc, v))
 }
 
 /// Renders the list as the VM's display text (`[1,2,3]` — comma separated,

--- a/lkrt/src/lklist.rs
+++ b/lkrt/src/lklist.rs
@@ -13,6 +13,31 @@
 
 use std::ffi::{CStr, CString, c_char, c_void};
 
+/// The live `str`-list behind a handle, re-derived per element so no borrow is
+/// held across a callback into generated code.
+///
+/// # Safety
+/// `handle` must be a live `str` list handle, or null.
+unsafe fn list_str(handle: *mut c_void) -> &'static [*const c_char] {
+    if handle.is_null() {
+        return &[];
+    }
+    // SAFETY: as the callers' contracts state.
+    unsafe { &*(handle as *mut Vec<*const c_char>) }
+}
+
+/// As [`list_str`], for an `i64` list.
+///
+/// # Safety
+/// `handle` must be a live `i64` list handle, or null.
+unsafe fn list_i64(handle: *mut c_void) -> &'static [i64] {
+    if handle.is_null() {
+        return &[];
+    }
+    // SAFETY: as the callers' contracts state.
+    unsafe { &*(handle as *mut Vec<i64>) }
+}
+
 /// Creates a fresh, empty `i64` list handle.
 /// Materializes an integer range (`a..b` / `a..=b`, optional step) as a
 /// `List<i64>` — the VM's `build_int_range` semantics exactly: zero step and
@@ -99,8 +124,23 @@ pub unsafe extern "C" fn lkrt_lklist_str_map_fn(
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = values.to_vec();
-    let mapped: Vec<*const c_char> = values.into_iter().map(|v| f(v)).collect();
+    // Indexed, and the handle is re-dereferenced each step: `f`/`p` re-enters
+    // generated code, which can push to *this* list (reallocating its buffer) or
+    // raise and longjmp past a borrow — so no slice may be held across the call.
+    // CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a
+    // lock guard or RefCell borrow") is the same rule; a slice borrow is a third
+    // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
+    // native HOF hot path the perf gate measures, and copying the whole input on
+    // top of the result allocation is not free.
+    let len = values.len();
+    let mut mapped: Vec<*const c_char> = Vec::with_capacity(len);
+    for index in 0..len {
+        // SAFETY: the handle is live per this function's contract.
+        let Some(&value) = unsafe { list_str(handle) }.get(index) else {
+            break;
+        };
+        mapped.push(f(value));
+    }
     crate::state::arena_handle(mapped)
 }
 
@@ -125,8 +165,25 @@ pub unsafe extern "C" fn lkrt_lklist_str_filter_fn(
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = values.to_vec();
-    let kept: Vec<*const c_char> = values.into_iter().filter(|&v| p(v)).collect();
+    // Indexed, and the handle is re-dereferenced each step: `f`/`p` re-enters
+    // generated code, which can push to *this* list (reallocating its buffer) or
+    // raise and longjmp past a borrow — so no slice may be held across the call.
+    // CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a
+    // lock guard or RefCell borrow") is the same rule; a slice borrow is a third
+    // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
+    // native HOF hot path the perf gate measures, and copying the whole input on
+    // top of the result allocation is not free.
+    let len = values.len();
+    let mut kept: Vec<*const c_char> = Vec::new();
+    for index in 0..len {
+        // SAFETY: the handle is live per this function's contract.
+        let Some(&value) = unsafe { list_str(handle) }.get(index) else {
+            break;
+        };
+        if p(value) {
+            kept.push(value);
+        }
+    }
     crate::state::arena_handle(kept)
 }
 
@@ -249,8 +306,23 @@ pub unsafe extern "C" fn lkrt_lklist_i64_map_fn(handle: *mut c_void, f: extern "
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = values.to_vec();
-    let mapped: Vec<i64> = values.into_iter().map(|v| f(v)).collect();
+    // Indexed, and the handle is re-dereferenced each step: `f`/`p` re-enters
+    // generated code, which can push to *this* list (reallocating its buffer) or
+    // raise and longjmp past a borrow — so no slice may be held across the call.
+    // CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a
+    // lock guard or RefCell borrow") is the same rule; a slice borrow is a third
+    // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
+    // native HOF hot path the perf gate measures, and copying the whole input on
+    // top of the result allocation is not free.
+    let len = values.len();
+    let mut mapped: Vec<i64> = Vec::with_capacity(len);
+    for index in 0..len {
+        // SAFETY: the handle is live per this function's contract.
+        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+            break;
+        };
+        mapped.push(f(value));
+    }
     crate::state::arena_handle(mapped)
 }
 
@@ -272,8 +344,25 @@ pub unsafe extern "C" fn lkrt_lklist_i64_filter_fn(handle: *mut c_void, p: exter
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = values.to_vec();
-    let kept: Vec<i64> = values.into_iter().filter(|&v| p(v)).collect();
+    // Indexed, and the handle is re-dereferenced each step: `f`/`p` re-enters
+    // generated code, which can push to *this* list (reallocating its buffer) or
+    // raise and longjmp past a borrow — so no slice may be held across the call.
+    // CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a
+    // lock guard or RefCell borrow") is the same rule; a slice borrow is a third
+    // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
+    // native HOF hot path the perf gate measures, and copying the whole input on
+    // top of the result allocation is not free.
+    let len = values.len();
+    let mut kept: Vec<i64> = Vec::new();
+    for index in 0..len {
+        // SAFETY: the handle is live per this function's contract.
+        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+            break;
+        };
+        if p(value) {
+            kept.push(value);
+        }
+    }
     crate::state::arena_handle(kept)
 }
 
@@ -393,8 +482,24 @@ pub unsafe extern "C" fn lkrt_lklist_i64_reduce_fn(
     // unsound. CLAUDE.md's lkrt rule ("never call a raise-capable function while
     // holding a lock guard or RefCell borrow") is the same rule; a slice borrow
     // is just a third way to hold one.
-    let values = values.to_vec();
-    values.into_iter().fold(init, |acc, v| f(acc, v))
+    // Indexed, and the handle is re-dereferenced each step: `f`/`p` re-enters
+    // generated code, which can push to *this* list (reallocating its buffer) or
+    // raise and longjmp past a borrow — so no slice may be held across the call.
+    // CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a
+    // lock guard or RefCell borrow") is the same rule; a slice borrow is a third
+    // way to hold one. Re-deref rather than a `to_vec()` snapshot: this is the
+    // native HOF hot path the perf gate measures, and copying the whole input on
+    // top of the result allocation is not free.
+    let len = values.len();
+    let mut acc = init;
+    for index in 0..len {
+        // SAFETY: the handle is live per this function's contract.
+        let Some(&value) = unsafe { list_i64(handle) }.get(index) else {
+            break;
+        };
+        acc = f(acc, value);
+    }
+    acc
 }
 
 /// Renders the list as the VM's display text (`[1,2,3]` — comma separated,

--- a/scripts/build_lkrt_asan.sh
+++ b/scripts/build_lkrt_asan.sh
@@ -40,9 +40,30 @@ if [ ! -f "$LIB" ]; then
     exit 1
 fi
 
+# `lk-api` too, with the *same* toolchain. A hybrid program links both archives,
+# each of which statically links `std`; two different rustc versions therefore
+# both define `rust_eh_personality` and the link fails. Same nightly for both
+# means the archives carry the identical `std` member, which the linker pulls
+# once. (No sanitizer flags here — instrumenting `lkrt` is the point; partial
+# instrumentation is fine, mismatched toolchains are not.)
+cargo +nightly build \
+    -p lk-api \
+    --features ffi \
+    --release \
+    --target "$TARGET" \
+    --target-dir "$TARGET_DIR" 1>&2
+
+API_LIB="$TARGET_DIR/$TARGET/release/liblk_api.a"
+if [ ! -f "$API_LIB" ]; then
+    echo "error: expected $API_LIB after the build" >&2
+    exit 1
+fi
+
 if [ "${1:-}" = "env" ]; then
     echo "export LKRT_STATICLIB=$(pwd)/$LIB"
+    echo "export LK_API_STATICLIB=$(pwd)/$API_LIB"
 else
     echo "built: $LIB" >&2
-    echo "export LKRT_STATICLIB=$(pwd)/$LIB to use it" >&2
+    echo "built: $API_LIB" >&2
+    echo "export LKRT_STATICLIB=$(pwd)/$LIB LK_API_STATICLIB=$(pwd)/$API_LIB to use them" >&2
 fi

--- a/todos.md
+++ b/todos.md
@@ -10,16 +10,27 @@
 
 ## P1 · 正确性,可复现
 
-### P1 类型检查器不看带标注的局部做返回类型推导
+### P1.1 解构 `let` 的元素类型没有分发
+
+`let [ok, v] = f()` 现在把 `v` 绑成 `Any`,因为原来的"每个名字都绑整个右值的类型"
+明显是错的(`v` 会被绑成整个 tuple)。**正解是把模式分发到类型上**:tuple 按位置、
+`List<T>` 按元素、union 逐成员分发。
+
+`Any` 是诚实的占位(不会凭空拒绝),但也就检查不出解构元素的类型错误。做完之后
+`core/src/stmt/stmt_impl/type_check.rs` 里那段注释要一并删掉。
+
+### P1.2 tuple 返回类型和自身的标注对不上
 
 ```lk
-fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
+fn pick(m: Map<String, String>, k: String) -> Tuple<Bool, String> {
+  if (m.get(k) == nil) { return [false, "missing"]; }
+  return [true, "found"];
+}
+// Return type mismatch in function 'pick': expected Tuple<Bool, String>, got Tuple<Bool, String>
 ```
 
-不带 try/catch 也复现,`lk check` / VM / AOT 三条路都中。**列表里唯一"写正常代码就
-撞得到、且 `lk check` 直接失败"的一条**,且和 AOT 那堆决策完全独立。
-
-(注:之前一度把它记成 try/catch 的 bug,是错的。)
+**显示完全一致却 unify 失败**,所以问题在 `Tuple` 的结构比较而不是显示。既存(和
+P1.1 的修复无关,是写它的回归测试时撞到的)。带标注的 tuple 返回目前写不出来。
 
 ---
 

--- a/todos.md
+++ b/todos.md
@@ -48,33 +48,6 @@ fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
 真语句化之后**未复验**(现在 try 不进 AOT)。AOT 外联做完之后应该一起消失,
 做完要回来确认。
 
-### AOT 直接调用的返回类型有两个真相源
-
-夜跑 fuzz 抓到的,`LK_FUZZ_SEED=30198012768 LK_FUZZ_CASES=500` 稳定复现
-(case `fuzz_476`;程序里 `fn fn_helper1(p0, p1) { return (p1 - 25); }` 的第二个
-参数被推成 `dyn`,于是返回也是 `dyn`)。
-
-MIR:
-
-```
-v114 = call f2(v105, v113)     ; f2(v0: i64, v1: dyn) -> dyn  → v114 是 dyn(寄存器对)
-v118 = call str.from_i64(v114) ; 却按 i64 处理 → 传 2 个机器参数给 1 参数的入口
-```
-
-调用点的结果类型取自 `sig.ret_types[callee]`
-(`lower_call.rs` 里 `let ret = sig.ret_types.get(callee_idx).copied().unwrap_or(Ty::I64)`),
-而 CLIF 声明取自被调函数自己的 `MirFunction::ret`。两者在收敛后仍然不一致,
-`lib.rs` 的定点循环没有消掉这个分歧(`sig.ret_types[fi] = mf.ret` 只在
-`!is_entry` 且本轮 `Ok` 时写回,而调用点在 entry 里)。
-
-要做的:让调用点的结果类型和 CLIF 声明来自同一处。
-
-诊断已经不需要再挖:两处新加的守卫会直接点名
-—— `Inst::Call` 处比对 ABI schema 的机器参数个数并报
-`str.from_i64 takes 1 machine argument(s) …, call site passes 2`,
-`raw_func` 处比对同名符号的签名冲突。在此之前 Cranelift 只会说
-`Module("Compilation error: Verifier errors")`。
-
 ### scope drop 的跨块限制
 
 实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:

--- a/todos.md
+++ b/todos.md
@@ -1,86 +1,71 @@
 # 待完成
 
-本轮 review + 修复过程中确认下来的开口项。每条都带复现或证据;没有复现过的会写明。
-做完一条就删掉它,不要在这里留"已完成"。
+本轮 review + 修复过程中确认下来的开口项,**按优先级排序**。每条都带复现或证据;
+没有复现过的会写明。做完一条就删掉它,不要在这里留"已完成"。
 
-## 已定方向、待补齐的
+排序依据:正确性 > 性能;普通代码撞得到 > 需要刻意构造;CI 正红 > 潜在;
+改动小且能消掉一整类问题的往前放。
 
-### try/catch 的 AOT 保护区外联
+---
 
-`try`/`catch` 已经是真语句(`Stmt::Try` → `TryBegin`/`TryEnd`),VM 侧完成。
-**AOT lowering 没有这两个 opcode 的处理**,优雅降级成 `Unsupported`。
+## P0 · 先花几分钟核实,结论会改变后面的排序
 
-已经按"先落 VM 侧、把回归写响"处理:
+三条都是"验证成本远低于修复成本",而且结论决定它们自己的优先级。
 
-- `AOT_COVERAGE_REQUIRE_FULL=1` **48/51**,三个 `examples/syntax/{try_catch,
-  error_unwrap,error_model_edges}.lk` 列在 `.github/workflows/check.yml` 的
-  `AOT_COVERAGE_ALLOW` 里,带理由;
-- `clif_differential_try_catch` 改名 `try_catch_differential`,允许降级、仍然断言
-  VM/native 输出一致 —— 保住的是等价,失去的是"走过 Cranelift";
-- 设计与欠账记在 `docs/aot/tier1-hybrid.md` 末尾。
+### P0.1 native `println` 打印 `List<str>` 不带引号
 
-**补齐之后要做的清理**:删掉 check.yml 里那三条 allow、把
-`try_catch_differential` 改回 `NativePath::PureCranelift`、删掉本条。
+与 VM 输出不一致(`[a-b,a-b]` vs `["a-b","a-b"]`)。**若为真,这是 VM/native 的错
+答案分歧**,不是排版问题 —— 整套差分设施就是为了防这个,而新加的严格 native 差分
+语料没覆盖到它。
 
-降级不影响正确性(三个例子输出与 VM 逐字节一致),但降级是**整程序** Tier 0
-而不是部分降级:它们的 try 在入口函数里,hybrid 桥不桥接入口。
+既存,main 上同样。**本人未复验**,来自第一轮 review 报告。先复现:为真则升到 P1
+之前并补一条差分用例;为假则删掉本条。
 
-## 开着的 bug
+### P0.2 `try { return x / 0; }` 是否还过不了 Cranelift verifier
 
-### 类型检查器不看带标注的局部做返回类型推导
+`Error: Cranelift codegen failed: Module("Compilation error: Verifier errors")`。
+既存 —— `LK_AOT_NO_OPT=1` 与改动前的 baseline 都复现。`LK_AOT_DUMP_MIR=1` 看得很
+清楚:外联出来的 `f1` 签名是 `-> i64`,但 `bb9` 上有一条裸 `ret`,去糖丢掉了
+"body 返回了"这个情况。
+
+真语句化之后**未复验**(现在 try 不进 AOT)。跑一次就知道:已消失就删掉本条,
+否则它是 P3 的一部分。
+
+### P0.3 ASan 下 hybrid 程序的 fuzz 差分是否已修
+
+`aot_fuzz_differential_test` 在 `LK_NATIVE_SANITIZE` 下报 "AOT compile failed
+without a graceful Unsupported reason"。这条观察**早于** `fix: hybrid 标记之后重新
+收敛签名`,而那个提交修的正是"codegen 硬失败而非优雅降级",所以可能已一并消失。
+
+若仍在:原因大概是 ASan 版 lkrt 与未插桩的 lk-api staticlib 混链,
+`scripts/build_lkrt_asan.sh` 的注释警告过这种 ABI 混用;不是 PR 门禁,降到 P5。
+
+---
+
+## P1 · 正确性,可复现,互不依赖
+
+### P1.1 类型检查器不看带标注的局部做返回类型推导
 
 ```lk
 fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
 ```
 
-不带 try/catch 也复现,`lk check` / VM / AOT 三条路都中。用户直接撞得到,且和上面
-的分支决策无关 —— 建议优先做这条。
+不带 try/catch 也复现,`lk check` / VM / AOT 三条路都中。**列表里唯一"写正常代码就
+撞得到、且 `lk check` 直接失败"的一条**,且和 AOT 那堆决策完全独立。
 
 (注:之前一度把它记成 try/catch 的 bug,是错的。)
 
-### `try { return x / 0; }` 在函数里过不了 Cranelift verifier
+### P1.2 `patch_branch` 用 `as i16` 截断跳转偏移
 
-`Error: Cranelift codegen failed: Module("Compilation error: Verifier errors")`。
-既存 —— `LK_AOT_NO_OPT=1` 与改动前的 baseline 都复现。从 `LK_AOT_DUMP_MIR=1` 看得
-很清楚:外联出来的 `f1` 签名是 `-> i64`,但 `bb9` 上有一条裸 `ret`,去糖丢掉了
-"body 返回了"这个情况。
+`core/src/vm/compiler/builder.rs`。超出 signed-bx 范围的分支目标会静默回绕成跳到别
+处,而不是编译失败。潜在 miscompile,但**改动是三行**(换 checked 转换 + 一条明确
+错误),能消掉一整类问题 —— 同文件新加的 `patch_try_begin` 已经这么做了,照抄。
 
-真语句化之后**未复验**(现在 try 不进 AOT)。AOT 外联做完之后应该一起消失,
-做完要回来确认。
+---
 
-### scope drop 的跨块限制
+## P2 · CI 正红,但先要一个能复现的环境
 
-实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:
-native 43.6 MB vs VM 22.7 MB,而 `LK_AOT_OPT_STATS=1` 报 `scope drops = 0` ——
-`if` 把块切开,句柄跨块,连容器都没释放。
-
-该做**跨块 liveness**。`aot/mir/src/opt.rs` 文档里"语料上 18 个循环分配中 3 个块
-内、0 个跨块但不逃逸"那句没覆盖这个形状,先用 `count_loop_allocations` 的第三个
-计数器在这个形状上复测。
-
-### `patch_branch` 用 `as i16` 截断跳转偏移
-
-`core/src/vm/compiler/builder.rs`。超出 signed-bx 范围的分支目标会静默回绕成跳到
-别处,而不是编译失败。同文件新加的 `patch_try_begin` 已经用 checked 转换,旧的那个
-没动。
-
-### builtin 类型的 impl 跨模块撞车
-
-`impl D for Int` 这类 impl 全部落在 `TypeScope::builtin()` 一个 scope 里,最后注册
-的赢。代码里有 `TODO(coherence)`。要一条 orphan rule 才能拒绝重叠 —— 是语言决策,
-不是分派修复。
-
-### `resolve_file_path` 的 `..` 不做真包含检查
-
-`core/src/vm/resolver.rs`,代码里有 `TODO(security)`。`starts_with(root)` 只是归一化
-偏好,逃出 root 的候选照样返回。要先定"`..` import 允许逃到哪个 root"。
-
-### native `println` 打印 `List<str>` 不带引号
-
-与 VM 输出不一致(`[a-b,a-b]` vs `["a-b","a-b"]`)。既存,main 上同样。新加的严格
-native 差分 CI 的语料没覆盖到。**本人未复验**,来自第一轮 review 报告。
-
-### ASan 下 `lkrt_lklist_i64_filter_fn` 报 stack-use-after-scope
+### P2.1 ASan 下 `lkrt_lklist_i64_filter_fn` 报 stack-use-after-scope
 
 main 的 CI("differential corpora with an ASan-instrumented lkrt" job)在
 `aot_differential_test::differential_builtins` /
@@ -94,26 +79,80 @@ AddressSanitizer: stack-use-after-scope
 ```
 
 `lkrt_lklist_i64_filter_fn` 在 `values.iter().copied().filter(|&v| p(v)).collect()`
-里跨着**回调进生成代码**持有源列表的 `&[i64]` 借用。两种可能:回调改动了同一个
-列表(Vec 重分配 → 迭代器悬空),或者回调 raise 时 longjmp 越过了 Rust 作用域
-而 ASan 的 poison 没被 `__asan_handle_no_return` 清掉(后者是**误报**,但同样红)。
-先分清是哪一种再决定改法。CLAUDE.md 里 lkrt 那条纪律("绝不在持有 lock guard /
-RefCell borrow 时调用可 raise 的函数")对**切片借用**同样适用,只是没写进去。
+里跨着**回调进生成代码**持有源列表的 `&[i64]` 借用。两种可能,先分清再定改法:
 
-**本地用仓库自己的 `scripts/build_lkrt_asan.sh` 构出 ASan lkrt 后不复现**,需要在
-CI 环境上查。
+1. 回调改动了同一个列表(Vec 重分配 → 迭代器悬空)—— **真的内存不安全**,是本列表
+   里可能最严重的一条;
+2. 回调 raise 时 longjmp 越过 Rust 作用域,ASan 的 poison 没被
+   `__asan_handle_no_return` 清掉 —— **误报**,但同样红。
 
-### ASan 下 hybrid 程序的 fuzz 差分失败
+CLAUDE.md 里 lkrt 那条纪律("绝不在持有 lock guard / RefCell borrow 时调用可 raise
+的函数")对**切片借用**同样适用,只是没写进去 —— 很可能就是根因。
 
-`aot_fuzz_differential_test` 在 `LK_NATIVE_SANITIZE` 下报 "AOT compile failed
-without a graceful Unsupported reason"。既存(stash 掉改动同样复现):ASan 版 lkrt
-与未插桩的 lk-api staticlib 混链,`scripts/build_lkrt_asan.sh` 自己的注释警告过这种
-ABI 混用。不是 PR 门禁,优先级低。
+**本地用仓库自己的 `scripts/build_lkrt_asan.sh` 构出 ASan lkrt 后不复现**,所以排在
+P1 之后:得先能复现。
 
-**注意**:这条的观察早于 `fix: hybrid 标记之后重新收敛签名`。那个提交修的正是
-"codegen 硬失败而非优雅降级",所以这条可能已经一并消失 —— 未复验。
+---
 
-## 已记档的覆盖上限(不是 bug)
+## P3 · 最大的一件,做完能收回一条硬门禁
+
+### P3.1 try/catch 的 AOT 保护区外联
+
+`try`/`catch` 已经是真语句(`Stmt::Try` → `TryBegin`/`TryEnd`),VM 侧完成。
+**AOT lowering 没有这两个 opcode 的处理**,优雅降级成 `Unsupported`。
+
+已经按"先落 VM 侧、把回归写响"处理:
+
+- `AOT_COVERAGE_REQUIRE_FULL=1` **48/51**,三个 `examples/syntax/{try_catch,
+  error_unwrap,error_model_edges}.lk` 列在 `.github/workflows/check.yml` 的
+  `AOT_COVERAGE_ALLOW` 里,带理由;
+- `clif_differential_try_catch` 改名 `try_catch_differential`,允许降级、仍然断言
+  VM/native 输出一致 —— 保住的是等价,失去的是"走过 Cranelift";
+- 设计与欠账记在 `docs/aot/tier1-hybrid.md` 末尾。
+
+降级不影响正确性(三个例子输出与 VM 逐字节一致),但降级是**整程序** Tier 0 而不是
+部分降级:它们的 try 在入口函数里,hybrid 桥不桥接入口。
+
+要做的:在 MIR lowering 里把保护区**外联**成函数(Cranelift 没有异常、lkrt 靠
+longjmp、setjmp 必须待在不会返回的帧里),外联函数返回三态(正常值 / raise /
+**外层函数要 return**),live-in 变参数、region 内写且 region 后仍活的值传回来。
+
+**补齐之后要做的清理**:删掉 check.yml 里那三条 allow、把 `try_catch_differential`
+改回 `NativePath::PureCranelift`、复验 P0.2、删掉本条。
+
+---
+
+## P4 · 先要一个语言决策,决定完实现很小
+
+### P4.1 `resolve_file_path` 的 `..` 不做真包含检查
+
+`core/src/vm/resolver.rs`,代码里有 `TODO(security)`。`starts_with(root)` 只是归一化
+偏好,逃出 root 的候选照样返回。要先定"`..` import 允许逃到哪个 root"—— 定完之后
+实现是几行。
+
+### P4.2 builtin 类型的 impl 跨模块撞车
+
+`impl D for Int` 这类 impl 全部落在 `TypeScope::builtin()` 一个 scope 里,最后注册
+的赢(静默的错答案)。代码里有 `TODO(coherence)`。要一条 orphan rule 才能拒绝重叠
+—— 是语言决策,不是分派修复。
+
+---
+
+## P5 · 只影响内存/性能
+
+### P5.1 scope drop 的跨块限制
+
+实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:
+native 43.6 MB vs VM 22.7 MB,而 `LK_AOT_OPT_STATS=1` 报 `scope drops = 0` ——
+`if` 把块切开,句柄跨块,连容器都没释放。
+
+该做**跨块 liveness**。`aot/mir/src/opt.rs` 文档里"语料上 18 个循环分配中 3 个块
+内、0 个跨块但不逃逸"那句没覆盖这个形状,先用 `count_loop_allocations` 的第三个
+计数器在这个形状上复测。
+
+---
+
+## 已记档的覆盖上限(不是 bug,不排优先级)
 
 这些是有意的保守取舍,写在这里只为免得被重新"发现"。
 

--- a/todos.md
+++ b/todos.md
@@ -80,12 +80,38 @@ native 43.6 MB vs VM 22.7 MB,而 `LK_AOT_OPT_STATS=1` 报 `scope drops = 0` —�
 与 VM 输出不一致(`[a-b,a-b]` vs `["a-b","a-b"]`)。既存,main 上同样。新加的严格
 native 差分 CI 的语料没覆盖到。**本人未复验**,来自第一轮 review 报告。
 
+### ASan 下 `lkrt_lklist_i64_filter_fn` 报 stack-use-after-scope
+
+main 的 CI("differential corpora with an ASan-instrumented lkrt" job)在
+`aot_differential_test::differential_builtins` /
+`builtins/list_hof_map_filter_reduce` 上失败:
+
+```
+AddressSanitizer: stack-use-after-scope
+  #0 <Copied<Iter<*const i8>> as Iterator>::size_hint
+  #1 <Vec<i64> as SpecFromIterNested<…, lkrt_lklist_i64_filter_fn::{closure#0}>>::from_iter
+  #2 lkrt_lklist_i64_filter_fn
+```
+
+`lkrt_lklist_i64_filter_fn` 在 `values.iter().copied().filter(|&v| p(v)).collect()`
+里跨着**回调进生成代码**持有源列表的 `&[i64]` 借用。两种可能:回调改动了同一个
+列表(Vec 重分配 → 迭代器悬空),或者回调 raise 时 longjmp 越过了 Rust 作用域
+而 ASan 的 poison 没被 `__asan_handle_no_return` 清掉(后者是**误报**,但同样红)。
+先分清是哪一种再决定改法。CLAUDE.md 里 lkrt 那条纪律("绝不在持有 lock guard /
+RefCell borrow 时调用可 raise 的函数")对**切片借用**同样适用,只是没写进去。
+
+**本地用仓库自己的 `scripts/build_lkrt_asan.sh` 构出 ASan lkrt 后不复现**,需要在
+CI 环境上查。
+
 ### ASan 下 hybrid 程序的 fuzz 差分失败
 
 `aot_fuzz_differential_test` 在 `LK_NATIVE_SANITIZE` 下报 "AOT compile failed
 without a graceful Unsupported reason"。既存(stash 掉改动同样复现):ASan 版 lkrt
 与未插桩的 lk-api staticlib 混链,`scripts/build_lkrt_asan.sh` 自己的注释警告过这种
 ABI 混用。不是 PR 门禁,优先级低。
+
+**注意**:这条的观察早于 `fix: hybrid 标记之后重新收敛签名`。那个提交修的正是
+"codegen 硬失败而非优雅降级",所以这条可能已经一并消失 —— 未复验。
 
 ## 已记档的覆盖上限(不是 bug)
 

--- a/todos.md
+++ b/todos.md
@@ -62,25 +62,9 @@ longjmp、setjmp 必须待在不会返回的帧里),外联函数返回三态(正
 
 ---
 
-## P3 · 先要一个语言决策,决定完实现很小
+## P3 · 只影响内存/性能
 
-### P3.1 `resolve_file_path` 的 `..` 不做真包含检查
-
-`core/src/vm/resolver.rs`,代码里有 `TODO(security)`。`starts_with(root)` 只是归一化
-偏好,逃出 root 的候选照样返回。要先定"`..` import 允许逃到哪个 root"—— 定完之后
-实现是几行。
-
-### P3.2 builtin 类型的 impl 跨模块撞车
-
-`impl D for Int` 这类 impl 全部落在 `TypeScope::builtin()` 一个 scope 里,最后注册
-的赢(静默的错答案)。代码里有 `TODO(coherence)`。要一条 orphan rule 才能拒绝重叠
-—— 是语言决策,不是分派修复。
-
----
-
-## P4 · 只影响内存/性能
-
-### P4.1 scope drop 的跨块限制
+### P3.1 scope drop 的跨块限制
 
 实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:
 native 43.6 MB vs VM 22.7 MB,而 `LK_AOT_OPT_STATS=1` 报 `scope drops = 0` ——

--- a/todos.md
+++ b/todos.md
@@ -8,43 +8,9 @@
 
 ---
 
-## P0 · 先花几分钟核实,结论会改变后面的排序
+## P1 · 正确性,可复现
 
-三条都是"验证成本远低于修复成本",而且结论决定它们自己的优先级。
-
-### P0.1 native `println` 打印 `List<str>` 不带引号
-
-与 VM 输出不一致(`[a-b,a-b]` vs `["a-b","a-b"]`)。**若为真,这是 VM/native 的错
-答案分歧**,不是排版问题 —— 整套差分设施就是为了防这个,而新加的严格 native 差分
-语料没覆盖到它。
-
-既存,main 上同样。**本人未复验**,来自第一轮 review 报告。先复现:为真则升到 P1
-之前并补一条差分用例;为假则删掉本条。
-
-### P0.2 `try { return x / 0; }` 是否还过不了 Cranelift verifier
-
-`Error: Cranelift codegen failed: Module("Compilation error: Verifier errors")`。
-既存 —— `LK_AOT_NO_OPT=1` 与改动前的 baseline 都复现。`LK_AOT_DUMP_MIR=1` 看得很
-清楚:外联出来的 `f1` 签名是 `-> i64`,但 `bb9` 上有一条裸 `ret`,去糖丢掉了
-"body 返回了"这个情况。
-
-真语句化之后**未复验**(现在 try 不进 AOT)。跑一次就知道:已消失就删掉本条,
-否则它是 P3 的一部分。
-
-### P0.3 ASan 下 hybrid 程序的 fuzz 差分是否已修
-
-`aot_fuzz_differential_test` 在 `LK_NATIVE_SANITIZE` 下报 "AOT compile failed
-without a graceful Unsupported reason"。这条观察**早于** `fix: hybrid 标记之后重新
-收敛签名`,而那个提交修的正是"codegen 硬失败而非优雅降级",所以可能已一并消失。
-
-若仍在:原因大概是 ASan 版 lkrt 与未插桩的 lk-api staticlib 混链,
-`scripts/build_lkrt_asan.sh` 的注释警告过这种 ABI 混用;不是 PR 门禁,降到 P5。
-
----
-
-## P1 · 正确性,可复现,互不依赖
-
-### P1.1 类型检查器不看带标注的局部做返回类型推导
+### P1 类型检查器不看带标注的局部做返回类型推导
 
 ```lk
 fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
@@ -55,48 +21,11 @@ fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
 
 (注:之前一度把它记成 try/catch 的 bug,是错的。)
 
-### P1.2 `patch_branch` 用 `as i16` 截断跳转偏移
-
-`core/src/vm/compiler/builder.rs`。超出 signed-bx 范围的分支目标会静默回绕成跳到别
-处,而不是编译失败。潜在 miscompile,但**改动是三行**(换 checked 转换 + 一条明确
-错误),能消掉一整类问题 —— 同文件新加的 `patch_try_begin` 已经这么做了,照抄。
-
 ---
 
-## P2 · CI 正红,但先要一个能复现的环境
+## P2 · 最大的一件,做完能收回一条硬门禁
 
-### P2.1 ASan 下 `lkrt_lklist_i64_filter_fn` 报 stack-use-after-scope
-
-main 的 CI("differential corpora with an ASan-instrumented lkrt" job)在
-`aot_differential_test::differential_builtins` /
-`builtins/list_hof_map_filter_reduce` 上失败:
-
-```
-AddressSanitizer: stack-use-after-scope
-  #0 <Copied<Iter<*const i8>> as Iterator>::size_hint
-  #1 <Vec<i64> as SpecFromIterNested<…, lkrt_lklist_i64_filter_fn::{closure#0}>>::from_iter
-  #2 lkrt_lklist_i64_filter_fn
-```
-
-`lkrt_lklist_i64_filter_fn` 在 `values.iter().copied().filter(|&v| p(v)).collect()`
-里跨着**回调进生成代码**持有源列表的 `&[i64]` 借用。两种可能,先分清再定改法:
-
-1. 回调改动了同一个列表(Vec 重分配 → 迭代器悬空)—— **真的内存不安全**,是本列表
-   里可能最严重的一条;
-2. 回调 raise 时 longjmp 越过 Rust 作用域,ASan 的 poison 没被
-   `__asan_handle_no_return` 清掉 —— **误报**,但同样红。
-
-CLAUDE.md 里 lkrt 那条纪律("绝不在持有 lock guard / RefCell borrow 时调用可 raise
-的函数")对**切片借用**同样适用,只是没写进去 —— 很可能就是根因。
-
-**本地用仓库自己的 `scripts/build_lkrt_asan.sh` 构出 ASan lkrt 后不复现**,所以排在
-P1 之后:得先能复现。
-
----
-
-## P3 · 最大的一件,做完能收回一条硬门禁
-
-### P3.1 try/catch 的 AOT 保护区外联
+### P2 try/catch 的 AOT 保护区外联
 
 `try`/`catch` 已经是真语句(`Stmt::Try` → `TryBegin`/`TryEnd`),VM 侧完成。
 **AOT lowering 没有这两个 opcode 的处理**,优雅降级成 `Unsupported`。
@@ -118,19 +47,19 @@ longjmp、setjmp 必须待在不会返回的帧里),外联函数返回三态(正
 **外层函数要 return**),live-in 变参数、region 内写且 region 后仍活的值传回来。
 
 **补齐之后要做的清理**:删掉 check.yml 里那三条 allow、把 `try_catch_differential`
-改回 `NativePath::PureCranelift`、复验 P0.2、删掉本条。
+改回 `NativePath::PureCranelift`、删掉本条。
 
 ---
 
-## P4 · 先要一个语言决策,决定完实现很小
+## P3 · 先要一个语言决策,决定完实现很小
 
-### P4.1 `resolve_file_path` 的 `..` 不做真包含检查
+### P3.1 `resolve_file_path` 的 `..` 不做真包含检查
 
 `core/src/vm/resolver.rs`,代码里有 `TODO(security)`。`starts_with(root)` 只是归一化
 偏好,逃出 root 的候选照样返回。要先定"`..` import 允许逃到哪个 root"—— 定完之后
 实现是几行。
 
-### P4.2 builtin 类型的 impl 跨模块撞车
+### P3.2 builtin 类型的 impl 跨模块撞车
 
 `impl D for Int` 这类 impl 全部落在 `TypeScope::builtin()` 一个 scope 里,最后注册
 的赢(静默的错答案)。代码里有 `TODO(coherence)`。要一条 orphan rule 才能拒绝重叠
@@ -138,9 +67,9 @@ longjmp、setjmp 必须待在不会返回的帧里),外联函数返回三态(正
 
 ---
 
-## P5 · 只影响内存/性能
+## P4 · 只影响内存/性能
 
-### P5.1 scope drop 的跨块限制
+### P4.1 scope drop 的跨块限制
 
 实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:
 native 43.6 MB vs VM 22.7 MB,而 `LK_AOT_OPT_STATS=1` 报 `scope drops = 0` ——

--- a/todos.md
+++ b/todos.md
@@ -25,6 +25,19 @@ fn g() -> Tuple<Bool, String> { return [true, "x"]; }   // 通过
 2. 列表字面量按**期望类型**推导(双向检查),保留 arity —— 正解,但要把期望类型
    传到字面量处。
 
+### P1.2 两个 anonymous 模块之间的 builtin impl 冲突查不出来
+
+`claim_builtin_impl` 按声明模块的 `TypeScope` 判定归属,而 `TypeScope::anonymous()`
+两两相等,所以两个匿名模块给同一个 builtin 实现同一个 trait 时,后者仍然静默覆盖
+前者 —— 正是这条检查要消掉的 import 顺序依赖,只是换到了内存/REPL 路径上。
+
+**目前在生产路径上不可达**:一次运行里只有入口程序是匿名的,
+`resolve_source_runtime`(唯一另一个匿名来源)没有生产调用方,只有测试用。加一个
+eval API 就会变得可达。
+
+要修得让匿名 scope 彼此可区分(现在 `type_info.rs` 的文档明确写着它"只靠是本次运行
+唯一的匿名 scope 来区分"),那会牵动 artifact 往返与相等性 —— 不是一处小改。
+
 ## P2 · 最大的一件,做完能收回一条硬门禁
 
 ### P2 try/catch 的 AOT 保护区外联

--- a/todos.md
+++ b/todos.md
@@ -48,6 +48,33 @@ fn f() -> Int { let r: Int = 0; r = 7; return r; }   // expected Int, got 'T0
 真语句化之后**未复验**(现在 try 不进 AOT)。AOT 外联做完之后应该一起消失,
 做完要回来确认。
 
+### AOT 直接调用的返回类型有两个真相源
+
+夜跑 fuzz 抓到的,`LK_FUZZ_SEED=30198012768 LK_FUZZ_CASES=500` 稳定复现
+(case `fuzz_476`;程序里 `fn fn_helper1(p0, p1) { return (p1 - 25); }` 的第二个
+参数被推成 `dyn`,于是返回也是 `dyn`)。
+
+MIR:
+
+```
+v114 = call f2(v105, v113)     ; f2(v0: i64, v1: dyn) -> dyn  → v114 是 dyn(寄存器对)
+v118 = call str.from_i64(v114) ; 却按 i64 处理 → 传 2 个机器参数给 1 参数的入口
+```
+
+调用点的结果类型取自 `sig.ret_types[callee]`
+(`lower_call.rs` 里 `let ret = sig.ret_types.get(callee_idx).copied().unwrap_or(Ty::I64)`),
+而 CLIF 声明取自被调函数自己的 `MirFunction::ret`。两者在收敛后仍然不一致,
+`lib.rs` 的定点循环没有消掉这个分歧(`sig.ret_types[fi] = mf.ret` 只在
+`!is_entry` 且本轮 `Ok` 时写回,而调用点在 entry 里)。
+
+要做的:让调用点的结果类型和 CLIF 声明来自同一处。
+
+诊断已经不需要再挖:两处新加的守卫会直接点名
+—— `Inst::Call` 处比对 ABI schema 的机器参数个数并报
+`str.from_i64 takes 1 machine argument(s) …, call site passes 2`,
+`raw_func` 处比对同名符号的签名冲突。在此之前 Cranelift 只会说
+`Module("Compilation error: Verifier errors")`。
+
 ### scope drop 的跨块限制
 
 实测 `for i in 0..200000 { let parts = s.split("-"); if parts[0] == "alpha" {…} }`:

--- a/todos.md
+++ b/todos.md
@@ -8,31 +8,22 @@
 
 ---
 
-## P1 · 正确性,可复现
+## P1 · 小,已定性
 
-### P1.1 解构 `let` 的元素类型没有分发
-
-`let [ok, v] = f()` 现在把 `v` 绑成 `Any`,因为原来的"每个名字都绑整个右值的类型"
-明显是错的(`v` 会被绑成整个 tuple)。**正解是把模式分发到类型上**:tuple 按位置、
-`List<T>` 按元素、union 逐成员分发。
-
-`Any` 是诚实的占位(不会凭空拒绝),但也就检查不出解构元素的类型错误。做完之后
-`core/src/stmt/stmt_impl/type_check.rs` 里那段注释要一并删掉。
-
-### P1.2 tuple 返回类型和自身的标注对不上
+### P1.1 同质列表字面量对不上 `Tuple` 标注
 
 ```lk
-fn pick(m: Map<String, String>, k: String) -> Tuple<Bool, String> {
-  if (m.get(k) == nil) { return [false, "missing"]; }
-  return [true, "found"];
-}
-// Return type mismatch in function 'pick': expected Tuple<Bool, String>, got Tuple<Bool, String>
+fn f() -> Tuple<Int, Int> { return [1, 2]; }   // expected Tuple<Int, Int>, got List<Int>
+fn g() -> Tuple<Bool, String> { return [true, "x"]; }   // 通过
 ```
 
-**显示完全一致却 unify 失败**,所以问题在 `Tuple` 的结构比较而不是显示。既存(和
-P1.1 的修复无关,是写它的回归测试时撞到的)。带标注的 tuple 返回目前写不出来。
+**同一种语法**按元素同质/异质推成 `List<Int>` 或 `Tuple<Bool, String>`,而只有后者
+能赋给 `Tuple` 标注。两条候选:
 
----
+1. 让 `is_assignable(List<T>, Tuple<T, …, T>)` 成立 —— 小,但丢掉 arity 保证
+   (长度 3 的 `List<Int>` 也能通过 `Tuple<Int, Int>`);
+2. 列表字面量按**期望类型**推导(双向检查),保留 arity —— 正解,但要把期望类型
+   传到字面量处。
 
 ## P2 · 最大的一件,做完能收回一条硬门禁
 

--- a/values/src/types.rs
+++ b/values/src/types.rs
@@ -357,6 +357,13 @@ impl Type {
 
             // Handle specific generic types
             match base {
+                // `Tuple<..>` is a first-class variant, not a user generic. It was
+                // missing here, so an annotation parsed as `Generic { name: "Tuple" }`
+                // while a heterogeneous list literal infers `Type::Tuple` — two
+                // different variants that `display()` renders identically, which is
+                // why `fn f() -> Tuple<Bool, String> { return [true, "x"]; }` failed
+                // with "expected Tuple<Bool, String>, got Tuple<Bool, String>".
+                "Tuple" => return Some(Type::Tuple(params)),
                 "List" => {
                     if params.len() == 1 {
                         return Some(Type::List(Box::new(params[0].clone())));


### PR DESCRIPTION
Starts from the two red workflows on `main` after #28, then works down `todos.md` in priority order. Nine functional commits; every one is gated (details at the bottom).

## The codegen miscompile

`main`'s nightly fresh-seed fuzz was failing with nothing but `Module("Compilation error: Verifier errors")`, which says nothing in a CI log. Three diagnostics were added first — an ABI arity check at the `Inst::Call` site (a `DynVal` is a register pair, so a machine-argument mismatch means the call site and the schema disagree), a signature-conflict check in `raw_func` (it cached by symbol name only, so a second request with a different signature silently got the first declaration), and `Debug` on `ModuleError::Compilation`. That turned the failure into one line:

```
str.from_i64 takes 1 machine argument(s) per the ABI schema, call site passes 2
```

**Root cause: a callee's return type had two sources of truth.** The call site reads `sig.ret_types[callee]`; the CLIF declaration uses the callee's own `MirFunction::ret`. The fixpoint reconciles them — but hybrid's mark-and-rerun happens *after* convergence, and marking a function VM-executed changes the type lattice (its callers now see the bridge's `Dyn` result, widening their own params and returns). `final_pass` never writes `ret_types` back, so a *native* callee whose parameter widened kept its pre-marking return type at every call site, and interpolating that result emitted `str.from_i64` on a register pair. Only reproducible with hybrid on: with `LK_AOT_HYBRID=0` the same program degrades gracefully to `Unsupported`.

Fix: the fixpoint is now a reusable closure, and the hybrid rerun re-converges before emitting. Both failing seeds (`30198012768`, `29984209887`) pass 500 cases each; the reduced shape is pinned by `clif_differential_bridge_taint_reconverges_ret_types` (seconds, vs. four minutes for the fuzz).

A second defect in the same area, found by review: the rerun re-converged the lattice but `mutable_globals` / `sig.gvar_of` were still computed once *before* the hybrid loop, while lowering keeps discovering globals. A slot typed only during the rerun has no `gvar_of` entry, `SigInfer::gvar` falls back to the raw slot number, and that can collide with a compacted id — aliasing two distinct globals onto one storage cell, with `validate` only bounds-checking. Silent miscompile, not a fallback. The compaction is now recomputed alongside the re-convergence.

## Red CI gates

**Rust Check** — three `-D warnings` errors in `lk-core --no-default-features` that an `--all-features` check cannot see: a dead `no_std` prelude import, `Path` used only under `std`, and `runtime_file_modules` never read without `std`. All four cross-target builds (wasm32 × 2, thumbv7em × 2) are clean.

**Correctness Harnesses** — the ASan job's hybrid failure was not a lowering problem but a link failure:

```
multiple definition of `rust_eh_personality'
  liblk_api.a  (stable  rustc)
  liblkrt.a    (nightly rustc)
```

`scripts/build_lkrt_asan.sh` builds `lkrt` with `+nightly` (`-Zsanitizer` requires it) while the driver built `lk-api` with the default toolchain; two `std` copies, two `rust_eh_personality`. Only hybrid programs link `lk-api`, so only they failed. `LK_API_STATICLIB` now lets a caller supply a matching archive (symmetric with the existing `LKRT_STATICLIB`), and the script builds both with one toolchain. **Hybrid programs are reached by ASan for the first time as a result**; all three sanitized suites pass locally.

## Soundness: lkrt HOFs held a borrow across a callback

The eight native `map`/`filter`/`reduce` entries held `&[T]` into the source list across `f`/`p`, which re-enter generated code — that callback can push to the same list (reallocating the buffer) or raise and longjmp past the borrow. CLAUDE.md's lkrt rule ("never call a raise-capable function while holding a lock guard or `RefCell` borrow") is the same rule; a slice borrow is a third way to hold one. Now indexed, re-dereferencing the handle each step — no borrow across the call and no copy, which matters because this is the native HOF path the perf gate measures.

CI reported `stack-use-after-scope` here; it does not reproduce locally even with a matching-toolchain ASan build, so whether that specific report was the dangling borrow or a longjmp/poison false positive is still open. The code was unsound either way.

## Type checker

- **A function body's block scope is the function scope.** The body was checked through `Stmt::Block`, which pushes a scope and pops it, so `collect_return_types` inferred `return r` with `r` already out of scope: `fn f() -> Int { let r: Int = 0; r = 7; return r; }` reported *expected Int, got 'T0*. Wrong returns are still rejected, including inside a `try` body.
- **A destructuring `let` distributes the pattern over the type.** It used to bind the whole right-hand side to every name, so `v` in `let [ok, v] = f()` was typed as the entire tuple — invisible only while inference was too coarse to produce a precise enough RHS. Tuple positions, list elements, map values, unions member-wise, `Optional` transparently; anything unrecognized yields `Any` rather than an invented type. `..rest` takes the union of the remaining positions.
- **`Tuple<..>` in an annotation is the `Tuple` type.** `Type::parse` handled `List`/`Map`/`Set`/`Task`/`Channel` but not `Tuple`, so an annotation became `Generic { name: "Tuple" }` while a heterogeneous list literal infers `Type::Tuple` — two variants that `display()` renders identically, hence *expected Tuple<Bool, String>, got Tuple<Bool, String>*.

## Two language-behaviour decisions (owner-approved)

**Imports may not leave their package.** `resolve_file_path` only rejected absolute paths; the `starts_with(root)` tests were a normalization preference, not a boundary (the fallback returned the path either way), so a program could read files outside its tree. The policy was also inconsistent: CLI arguments go through `sanitize_path`, which rejects `..`, while imports were unchecked. The boundary is now the nearest `Lk.toml` directory, falling back to the importing file's own directory; `..` stays legal as a way to reach a sibling directory of the same package. Three things had to change together: a bare `lk main.lk` never called `set_base_dir` (empty parent), `find_manifest` must run *after* canonicalization (a relative `.` has no parents to walk), and an out-of-root candidate must *skip* rather than abort the search — `search_paths` always starts with `.` and `core`, so a name that also exists in cwd was hard-failing an import whose real target sat under a later root. `examples/Lk.toml` was added so the repo's own `../` imports stay inside a package and the boundary does not depend on cwd.

**One trait may be implemented for a builtin type only once.** A builtin has no declaring module, so every module's impls for it share one scope and the later registration silently overwrote the earlier: with two modules implementing `Doubler for Int`, `(5).dbl()` answered whichever was imported *last*. The conflict is now reported, naming both modules. Only programs whose answer was already undetermined are rejected — a single module implementing a trait for a builtin is unaffected, and re-registering the same module (REPL, hybrid bridge, transitive imports) is not a conflict.

## Also

`patch_branch` truncated its jump offset with `as i16`, so a branch target outside the signed-bx range wrapped into a jump somewhere else instead of failing the compile.

`todos.md` records what is still open, in priority order, with a repro or evidence per item and an explicit note where I did not reproduce something myself.

## Gates

- `cargo test --workspace --all-features` — 108 suites, clean
- `cargo clippy --workspace --all-features --tests` — clean
- `AOT_COVERAGE_REQUIRE_FULL=1 scripts/aot_coverage.sh` — passes at 48/51 with three `AOT_COVERAGE_ALLOW` entries (the try/catch corpus; see below)
- `LK_AOT_NO_FALLBACK=1` strict differential — `aot_differential_test` + `clif_differential_test` clean
- `no_std` cross targets — wasm32 × 2, thumbv7em × 2, all `-D warnings`
- Sanitized differential — all three suites clean, hybrid programs included
- Workload bench — geometric mean **0.996x** (1.004x on the same machine before the HOF change)

## Pre-existing debt this PR carries, not introduces

`try`/`catch` became a real statement in #28's tail; the MIR lowering has no handler-region support yet, so the three try/catch examples degrade to the Tier 0 bundle. Output stays VM-identical (`try_catch_differential` pins it, with fallback allowed); what lapses is *native* lowering. The allow-list entries, the cleanup checklist, and the outlining design are recorded in `check.yml`, `docs/aot/tier1-hybrid.md`, and `todos.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `Tuple<...>` type annotations.
  * Added `LK_API_STATICLIB` environment override for native API static library selection.
  * Enforced package-boundary protection for file/module imports (with clearer “outside boundary” errors).

* **Bug Fixes**
  * Improved type checking for destructured `let` bindings, function returns, and `return` inside `try/catch`.
  * Rejected conflicting builtin trait implementations deterministically.
  * Improved diagnostics for native/call signature mismatches and prevented unsafe jump offset truncation.
  * Made list/mixed-list callbacks re-entrancy-safe.

* **Tests**
  * Added AOT differential and overlapping-builtin-impl rejection regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->